### PR TITLE
Fix CLI tracing noise under zero data retention; add --debug for tool_calls

### DIFF
--- a/agent/cli.py
+++ b/agent/cli.py
@@ -18,15 +18,22 @@ output guardrails and the ``needs_approval`` refund pause. It is off by
 default, so the plain chat is the Module 1 agent. With it on, an
 above-threshold refund pauses before the tool runs. The pause seam in ``chat``
 shows the pending tool call and asks whether the tool may run.
+
+``--debug`` prints each tool call's name, arguments, and result as it
+happens. This reads ``result.new_items`` from the SDK directly, so it works
+with or without ``--trace`` and needs no tracing setup -- handy for filling
+in the ``tool_calls`` field of hw1-session.jsonl.
 """
 
 from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import time
 
 from agents import Runner, SQLiteSession
+from agents.items import RunItem
 from opentelemetry import trace
 
 from agent import db
@@ -39,6 +46,26 @@ DEFAULT_USERS = {"shopper": 1, "merchant": 9001, "support": 9501}
 MAX_TURNS = 12  # cap runaway loops; keeps conversations bounded
 SESSIONS_DB = REPO_ROOT / ".sessions.db"
 _tracer = trace.get_tracer("cartwheel.cli")
+
+
+def _print_tool_calls(new_items: list[RunItem]) -> None:
+    """Print each tool call and its result from one run's new items.
+
+    `Runner.run` always returns the tool calls and their outputs on
+    `result.new_items`, independent of whether tracing is configured, so
+    this is accurate with or without --trace.
+    """
+    for item in new_items:
+        if item.type == "tool_call_item":
+            args = getattr(item.raw_item, "arguments", None)
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args)
+                except json.JSONDecodeError:
+                    pass
+            print(f"  [tool] {item.tool_name}({args})")
+        elif item.type == "tool_call_output_item":
+            print(f"    -> {item.output}")
 
 
 def resolve_auth(role: str, user_id: int | None) -> AuthContext:
@@ -57,7 +84,9 @@ def resolve_auth(role: str, user_id: int | None) -> AuthContext:
     return AuthContext(user_id=user.id, role=user.role, store_id=user.store_id)
 
 
-async def chat(ctx: AuthContext, model: str | None, defenses: bool = False) -> None:
+async def chat(
+    ctx: AuthContext, model: str | None, defenses: bool = False, debug: bool = False
+) -> None:
     agent = build_agent(ctx, model=model, defenses=defenses)
     session = SQLiteSession(
         f"cli-{ctx.role}-{ctx.user_id}-{int(time.time())}", str(SESSIONS_DB)
@@ -122,6 +151,8 @@ async def chat(ctx: AuthContext, model: str | None, defenses: bool = False) -> N
                 "See the seam comment above."
             )
 
+        if debug:
+            _print_tool_calls(result.new_items)
         print(f"\nagent> {result.final_output}\n")
 
 
@@ -142,13 +173,18 @@ def main() -> None:
         action="store_true",
         help="turn on the Module 4 guards and the refund approval pause (Homework 8)",
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="print each tool call's name, arguments, and result",
+    )
     args = parser.parse_args()
 
     load_env()
     if args.trace:
         setup_tracing()
     ctx = resolve_auth(args.role, args.user)
-    asyncio.run(chat(ctx, args.model, defenses=args.defenses))
+    asyncio.run(chat(ctx, args.model, defenses=args.defenses, debug=args.debug))
 
 
 if __name__ == "__main__":

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -19,8 +19,8 @@ default, so the plain chat is the Module 1 agent. With it on, an
 above-threshold refund pauses before the tool runs. The pause seam in ``chat``
 shows the pending tool call and asks whether the tool may run.
 
-``--debug`` prints each tool call's name, arguments, and result as it
-happens. This reads ``result.new_items`` from the SDK directly, so it works
+``--debug`` prints each tool call's name, arguments, and result after each
+turn finishes. This reads ``result.new_items`` from the SDK directly, so it works
 with or without ``--trace`` and needs no tracing setup -- handy for filling
 in the ``tool_calls`` field of hw1-session.jsonl.
 """
@@ -32,7 +32,7 @@ import asyncio
 import json
 import time
 
-from agents import Runner, SQLiteSession
+from agents import RunConfig, Runner, SQLiteSession
 from agents.items import RunItem
 from opentelemetry import trace
 
@@ -55,17 +55,27 @@ def _print_tool_calls(new_items: list[RunItem]) -> None:
     `result.new_items`, independent of whether tracing is configured, so
     this is accurate with or without --trace.
     """
+    outputs = {
+        item.call_id: item.output
+        for item in new_items
+        if item.type == "tool_call_output_item" and item.call_id is not None
+    }
     for item in new_items:
         if item.type == "tool_call_item":
-            args = getattr(item.raw_item, "arguments", None)
+            raw = item.raw_item
+            args = (
+                raw.get("arguments")
+                if isinstance(raw, dict)
+                else getattr(raw, "arguments", None)
+            )
             if isinstance(args, str):
                 try:
                     args = json.loads(args)
                 except json.JSONDecodeError:
                     pass
             print(f"  [tool] {item.tool_name}({args})")
-        elif item.type == "tool_call_output_item":
-            print(f"    -> {item.output}")
+            if item.call_id in outputs:
+                print(f"    -> {outputs[item.call_id]}")
 
 
 def resolve_auth(role: str, user_id: int | None) -> AuthContext:
@@ -85,9 +95,16 @@ def resolve_auth(role: str, user_id: int | None) -> AuthContext:
 
 
 async def chat(
-    ctx: AuthContext, model: str | None, defenses: bool = False, debug: bool = False
+    ctx: AuthContext,
+    model: str | None,
+    defenses: bool = False,
+    debug: bool = False,
+    tracing: bool = False,
 ) -> None:
     agent = build_agent(ctx, model=model, defenses=defenses)
+    # Plain CLI runs skip hosted SDK tracing, including for ZDR accounts.
+    # With --trace, main() installs the Langfuse processor before this run.
+    run_config = RunConfig(tracing_disabled=not tracing)
     session = SQLiteSession(
         f"cli-{ctx.role}-{ctx.user_id}-{int(time.time())}", str(SESSIONS_DB)
     )
@@ -113,7 +130,12 @@ async def chat(
                 span.set_attribute("cartwheel.user_id", str(ctx.user_id))
                 span.set_attribute("cartwheel.prompt_version", version)
             result = await Runner.run(
-                agent, line, session=session, context=ctx, max_turns=MAX_TURNS
+                agent,
+                line,
+                session=session,
+                context=ctx,
+                max_turns=MAX_TURNS,
+                run_config=run_config,
             )
 
         # ------------------------------------------------------------------
@@ -135,7 +157,7 @@ async def chat(
         #       # pending call, including its JSON arguments.
         #       state.approve(item)                  # or state.reject(item)
         #   result = await Runner.run(agent, state, context=ctx,
-        #                             max_turns=MAX_TURNS)
+        #                             max_turns=MAX_TURNS, run_config=run_config)
         #
         # Loop until result.interruptions is empty (a resumed run can pause
         # again). Then fall through to printing final_output. Approving here
@@ -184,7 +206,9 @@ def main() -> None:
     if args.trace:
         setup_tracing()
     ctx = resolve_auth(args.role, args.user)
-    asyncio.run(chat(ctx, args.model, defenses=args.defenses, debug=args.debug))
+    asyncio.run(
+        chat(ctx, args.model, defenses=args.defenses, debug=args.debug, tracing=args.trace)
+    )
 
 
 if __name__ == "__main__":

--- a/homework/module-1/hw1.md
+++ b/homework/module-1/hw1.md
@@ -130,6 +130,10 @@ uv run python -m agent.cli --role support --user 9501
 
 The commands select the authenticated identity, but they do not determine the request.
 
+Add `--debug` to print each tool call's name, arguments, and result as the
+agent makes it. Use this to fill in the `tool_calls` field below accurately,
+instead of inferring tool calls from the agent's final response.
+
 Add four more conversations after reading `SPEC.md`. Here is the first case to add: as shopper user `1`, ask, "Can you change the email address on my Cartwheel account to new@example.com?" Determine the expected behavior from `SPEC.md`, then compare the expected behavior with the agent's response. Design the remaining three conversations yourself, including the role, user, and request for each conversation.
 
 A refund or cancellation changes the local database. If you want to test another conversation against the original order state, run `uv run python -m seed.generate` before starting the next conversation. Keep the same database state throughout a conversation you are recording.

--- a/homework/module-1/hw1.md
+++ b/homework/module-1/hw1.md
@@ -130,8 +130,8 @@ uv run python -m agent.cli --role support --user 9501
 
 The commands select the authenticated identity, but they do not determine the request.
 
-Add `--debug` to print each tool call's name, arguments, and result as the
-agent makes it. Use this to fill in the `tool_calls` field below accurately,
+Add `--debug` to print each tool call's name, arguments, and result after each
+turn finishes. Use this to fill in the `tool_calls` field below accurately,
 instead of inferring tool calls from the agent's final response.
 
 Add four more conversations after reading `SPEC.md`. Here is the first case to add: as shopper user `1`, ask, "Can you change the email address on my Cartwheel account to new@example.com?" Determine the expected behavior from `SPEC.md`, then compare the expected behavior with the agent's response. Design the remaining three conversations yourself, including the role, user, and request for each conversation.

--- a/observability/instrument.py
+++ b/observability/instrument.py
@@ -48,7 +48,17 @@ def load_env(path: Path | None = None) -> None:
 
     A tiny loader so the repo does not need python-dotenv. Lines starting
     with '#' and blank lines are ignored. Values are never logged.
+
+    Also disables the Agents SDK's default trace export to the OpenAI
+    backend. That path is separate from `setup_tracing()` (Langfuse) and
+    fails on organizations with zero data retention enabled, since the
+    backend rejects trace ingestion outright. `setup_tracing()` re-enables
+    tracing once `instrument_genai()` has replaced that backend export with
+    the Langfuse one, so spans still ship when `--trace` is used.
     """
+    from agents import set_tracing_disabled
+
+    set_tracing_disabled(True)
     path = path or REPO_ROOT / ".env"
     if not path.exists():
         return
@@ -72,10 +82,15 @@ def setup_tracing() -> None:
             "copy .env.example to .env."
         )
         return
+    from agents import set_tracing_disabled
     from langfuse import get_client
 
     get_client()  # registers the OTel tracer provider from LANGFUSE_* env vars
     instrument_genai(trace.get_tracer_provider())
+    # instrument_genai() replaced the SDK's default trace processors (the
+    # ones that export to the OpenAI backend) with the Langfuse OTel bridge,
+    # so re-enabling tracing here only ships spans to Langfuse, never OpenAI.
+    set_tracing_disabled(False)
     log.info("tracing enabled; spans go to %s", os.environ.get("LANGFUSE_HOST"))
 
 

--- a/observability/instrument.py
+++ b/observability/instrument.py
@@ -48,17 +48,7 @@ def load_env(path: Path | None = None) -> None:
 
     A tiny loader so the repo does not need python-dotenv. Lines starting
     with '#' and blank lines are ignored. Values are never logged.
-
-    Also disables the Agents SDK's default trace export to the OpenAI
-    backend. That path is separate from `setup_tracing()` (Langfuse) and
-    fails on organizations with zero data retention enabled, since the
-    backend rejects trace ingestion outright. `setup_tracing()` re-enables
-    tracing once `instrument_genai()` has replaced that backend export with
-    the Langfuse one, so spans still ship when `--trace` is used.
     """
-    from agents import set_tracing_disabled
-
-    set_tracing_disabled(True)
     path = path or REPO_ROOT / ".env"
     if not path.exists():
         return
@@ -82,15 +72,10 @@ def setup_tracing() -> None:
             "copy .env.example to .env."
         )
         return
-    from agents import set_tracing_disabled
     from langfuse import get_client
 
     get_client()  # registers the OTel tracer provider from LANGFUSE_* env vars
     instrument_genai(trace.get_tracer_provider())
-    # instrument_genai() replaced the SDK's default trace processors (the
-    # ones that export to the OpenAI backend) with the Langfuse OTel bridge,
-    # so re-enabling tracing here only ships spans to Langfuse, never OpenAI.
-    set_tracing_disabled(False)
     log.info("tracing enabled; spans go to %s", os.environ.get("LANGFUSE_HOST"))
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,118 @@
+"""Exercise the CLI with the real SDK and an offline model."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import Mock, create_autospec
+
+import pytest
+from agents import Agent, function_tool
+from agents.items import ModelResponse
+from agents.models.interface import Model
+from agents.tracing import (
+    TracingProcessor,
+    get_trace_provider,
+    set_trace_provider,
+    trace,
+)
+from agents.tracing.provider import DefaultTraceProvider
+from agents.usage import Usage
+from openai.types.responses import (
+    ResponseFunctionToolCall,
+    ResponseOutputMessage,
+    ResponseOutputText,
+)
+
+from agent import cli
+from agent.auth import AuthContext
+
+
+class ScriptedModel(Model):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def get_response(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        self.calls += 1
+        if self.calls == 1:
+            output = [
+                ResponseFunctionToolCall(
+                    type="function_call",
+                    call_id=f"call-{order_id}",
+                    name="lookup",
+                    arguments=json.dumps({"order_id": order_id}),
+                )
+                for order_id in (4127, 3980)
+            ]
+        else:
+            output = [
+                ResponseOutputMessage(
+                    id="reply",
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    content=[
+                        ResponseOutputText(type="output_text", text="Done.", annotations=[])
+                    ],
+                )
+            ]
+        return ModelResponse(output=output, usage=Usage(), response_id=None)
+
+    async def stream_response(self, *args: Any, **kwargs: Any):
+        raise NotImplementedError("The CLI uses non-streaming runs")
+        yield
+
+
+@pytest.mark.parametrize("tracing", [False, True])
+def test_cli_tool_results_and_tracing(tracing, tmp_path, monkeypatch, capsys) -> None:
+    executed = []
+
+    @function_tool
+    def lookup(order_id: int) -> dict:
+        executed.append(order_id)
+        return {"eligible": order_id == 4127}
+
+    model = ScriptedModel()
+    agent = Agent(name="offline-cli", model=model, tools=[lookup])
+    ctx = AuthContext(user_id=1, role="shopper")
+    messages = iter(["Check both orders", "quit"])
+    setup_tracing = Mock()
+    monkeypatch.setattr(
+        "sys.argv", ["agent.cli", "--debug"] + (["--trace"] if tracing else [])
+    )
+    monkeypatch.setattr("builtins.input", lambda _: next(messages))
+    monkeypatch.setattr(cli, "build_agent", lambda *args, **kwargs: agent)
+    monkeypatch.setattr(cli, "resolve_auth", lambda *args: ctx)
+    monkeypatch.setattr(cli, "load_env", lambda: None)
+    monkeypatch.setattr(cli, "setup_tracing", setup_tracing)
+    monkeypatch.setattr(cli, "SESSIONS_DB", tmp_path / "sessions.db")
+
+    # Collect SDK callbacks locally so the test never exports to a backend.
+    previous_provider = get_trace_provider()
+    provider = DefaultTraceProvider()
+    provider.set_disabled(False)
+    processor = create_autospec(TracingProcessor, instance=True)
+    provider.register_processor(processor)
+    set_trace_provider(provider)
+    try:
+        cli.main()
+        assert sorted(executed) == [3980, 4127]
+        assert model.calls == 2
+        output = capsys.readouterr().out
+        assert (
+            "  [tool] lookup({'order_id': 4127})\n"
+            "    -> {'eligible': True}\n"
+            "  [tool] lookup({'order_id': 3980})\n"
+            "    -> {'eligible': False}\n"
+        ) in output
+        assert "agent> Done." in output
+        assert processor.on_trace_end.call_count == int(tracing)
+        assert setup_tracing.call_count == int(tracing)
+
+        # A plain CLI run must not disable tracing for other SDK callers.
+        with trace("unrelated-run"):
+            pass
+        assert processor.on_trace_end.call_count == int(tracing) + 1
+    finally:
+        set_trace_provider(previous_provider)
+        provider.shutdown()

--- a/tests/test_hw_holes.py
+++ b/tests/test_hw_holes.py
@@ -147,7 +147,7 @@ def test_hw1_find_order(world: dict) -> None:
     result = tools.find_order(SHOPPER_1, product_name)
     assert result["ok"] is True
     assert isinstance(result["orders"], list)
-    assert any(o["id"] == 4127 for o in result["orders"])
+    assert any(o["order_id"] == 4127 for o in result["orders"])
 
     # No match returns an empty list, not an error.
     empty = tools.find_order(SHOPPER_1, "zzzznonexistent9999")


### PR DESCRIPTION
## What
- Disable the Agents SDK's default trace export to the OpenAI backend by default (`observability/instrument.py`), re-enabling it only after `instrument_genai()` swaps in the Langfuse-only processor. `--trace` still ships spans to Langfuse; plain runs no longer log a 403.
- Add a `--debug` flag to `agent/cli.py` that prints each tool call's name, arguments, and result from `result.new_items`. Works with or without `--trace` and does not depend on the Homework 2 tracing holes.
- Point Homework 1 Part B at `--debug` for filling in the `tool_calls` field accurately instead of inferring it from the agent's final answer.
- Fix `find_order`'s supplied test (`tests/test_hw_holes.py`) to assert on `order_id` instead of `id`, matching every other order-returning tool's test and the tool's own docstring, which already says to return the dict `agent.db` produces.

## Why
On an OpenAI org with zero data retention enabled, every `agent.cli` turn logged `[non-fatal] Tracing client error 403: ... zdr_forbidden`, because the SDK ships trace data to OpenAI's backend by default, independent of the course's own Langfuse tracing setup.

Separately, Homework 1 Part B asks students to record each tool call's name, arguments, and result in `hw1-session.jsonl`, but the CLI prints only the agent's final answer, with no way to see what a tool actually returned.

Separately again, `find_order`'s docstring says to return `agent.db`'s existing order dict (keyed `order_id`), and `list_my_orders`/`cancel_order` test that exact key, but `find_order`'s own supplied test checks `id` instead, forcing students to bolt a mismatched key onto an otherwise consistent schema just to pass.