### PR TITLE
fix: expose tool results for Homework 1

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -29,6 +29,8 @@ jobs:
         run: uv run pytest tests/eval -k "unit or integration" -q
       - name: Homework structural checks
         run: uv run pytest tests/test_hw_holes.py -q
+      - name: CLI debug output, with no model keys
+        run: uv run pytest tests/test_cli.py -q
 
   complete-evaluations:
     name: complete evaluations and leakage check

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -24,9 +24,11 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import time
 
 from agents import Runner, SQLiteSession
+from agents.items import RunItem
 from opentelemetry import trace
 
 from agent import db
@@ -39,6 +41,36 @@ DEFAULT_USERS = {"shopper": 1, "merchant": 9001, "support": 9501}
 MAX_TURNS = 12  # cap runaway loops; keeps conversations bounded
 SESSIONS_DB = REPO_ROOT / ".sessions.db"
 _tracer = trace.get_tracer("cartwheel.cli")
+
+
+def _print_tool_calls(new_items: list[RunItem]) -> None:
+    """Print each tool call and its result from one run's new items.
+
+    `Runner.run` always returns the tool calls and their outputs on
+    `result.new_items`, independent of whether tracing is configured, so
+    this is accurate with or without --trace.
+    """
+    outputs = {
+        item.call_id: item.output
+        for item in new_items
+        if item.type == "tool_call_output_item" and item.call_id is not None
+    }
+    for item in new_items:
+        if item.type == "tool_call_item":
+            raw = item.raw_item
+            args = (
+                raw.get("arguments")
+                if isinstance(raw, dict)
+                else getattr(raw, "arguments", None)
+            )
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args)
+                except json.JSONDecodeError:
+                    pass
+            print(f"  [tool] {item.tool_name}({args})")
+            if item.call_id in outputs:
+                print(f"    -> {outputs[item.call_id]}")
 
 
 def resolve_auth(role: str, user_id: int | None) -> AuthContext:
@@ -57,7 +89,9 @@ def resolve_auth(role: str, user_id: int | None) -> AuthContext:
     return AuthContext(user_id=user.id, role=user.role, store_id=user.store_id)
 
 
-async def chat(ctx: AuthContext, model: str | None, defenses: bool = False) -> None:
+async def chat(
+    ctx: AuthContext, model: str | None, defenses: bool = False, debug: bool = False
+) -> None:
     agent = build_agent(ctx, model=model, defenses=defenses)
     session = SQLiteSession(
         f"cli-{ctx.role}-{ctx.user_id}-{int(time.time())}", str(SESSIONS_DB)
@@ -122,6 +156,8 @@ async def chat(ctx: AuthContext, model: str | None, defenses: bool = False) -> N
                 "See the seam comment above."
             )
 
+        if debug:
+            _print_tool_calls(result.new_items)
         print(f"\nagent> {result.final_output}\n")
 
 
@@ -142,13 +178,18 @@ def main() -> None:
         action="store_true",
         help="turn on the Module 4 guards and the refund approval pause (Homework 8)",
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="print each tool call's name, arguments, and result",
+    )
     args = parser.parse_args()
 
     load_env()
     if args.trace:
         setup_tracing()
     ctx = resolve_auth(args.role, args.user)
-    asyncio.run(chat(ctx, args.model, defenses=args.defenses))
+    asyncio.run(chat(ctx, args.model, defenses=args.defenses, debug=args.debug))
 
 
 if __name__ == "__main__":

--- a/homework/module-1/hw1.md
+++ b/homework/module-1/hw1.md
@@ -130,6 +130,14 @@ uv run python -m agent.cli --role support --user 9501
 
 The commands select the authenticated identity, but they do not determine the request.
 
+Add `--debug` to print each tool call's name, arguments, and result after each
+turn finishes. Use this output to fill in `tool_calls` in `hw1-session.jsonl`.
+This works without Langfuse or the Homework 2 tracing setup. For example:
+
+```bash
+uv run python -m agent.cli --role shopper --user 1 --debug
+```
+
 Add four more conversations after reading `SPEC.md`. Here is the first case to add: as shopper user `1`, ask, "Can you change the email address on my Cartwheel account to new@example.com?" Determine the expected behavior from `SPEC.md`, then compare the expected behavior with the agent's response. Design the remaining three conversations yourself, including the role, user, and request for each conversation.
 
 A refund or cancellation changes the local database. If you want to test another conversation against the original order state, run `uv run python -m seed.generate` before starting the next conversation. Keep the same database state throughout a conversation you are recording.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,102 @@
+"""Exercise the CLI with the real SDK and an offline model."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from agents import Agent, function_tool
+from agents.items import ModelResponse
+from agents.models.interface import Model
+from agents.tracing import get_trace_provider, set_trace_provider
+from agents.tracing.provider import DefaultTraceProvider
+from agents.usage import Usage
+from openai.types.responses import (
+    ResponseFunctionToolCall,
+    ResponseOutputMessage,
+    ResponseOutputText,
+)
+
+from agent import cli
+from agent.auth import AuthContext
+
+
+class ScriptedModel(Model):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def get_response(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        self.calls += 1
+        if self.calls == 1:
+            output = [
+                ResponseFunctionToolCall(
+                    type="function_call",
+                    call_id=f"call-{order_id}",
+                    name="lookup",
+                    arguments=json.dumps({"order_id": order_id}),
+                )
+                for order_id in (4127, 3980)
+            ]
+        else:
+            output = [
+                ResponseOutputMessage(
+                    id="reply",
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    content=[
+                        ResponseOutputText(type="output_text", text="Done.", annotations=[])
+                    ],
+                )
+            ]
+        return ModelResponse(output=output, usage=Usage(), response_id=None)
+
+    async def stream_response(self, *args: Any, **kwargs: Any):
+        raise NotImplementedError("The CLI uses non-streaming runs")
+        yield
+
+
+@pytest.mark.parametrize("debug", [False, True])
+def test_cli_tool_results(debug, tmp_path, monkeypatch, capsys) -> None:
+    executed = []
+
+    @function_tool
+    def lookup(order_id: int) -> dict:
+        executed.append(order_id)
+        return {"eligible": order_id == 4127}
+
+    model = ScriptedModel()
+    agent = Agent(name="offline-cli", model=model, tools=[lookup])
+    ctx = AuthContext(user_id=1, role="shopper")
+    messages = iter(["Check both orders", "quit"])
+    monkeypatch.setattr("sys.argv", ["agent.cli"] + (["--debug"] if debug else []))
+    monkeypatch.setattr("builtins.input", lambda _: next(messages))
+    monkeypatch.setattr(cli, "build_agent", lambda *args, **kwargs: agent)
+    monkeypatch.setattr(cli, "resolve_auth", lambda *args: ctx)
+    monkeypatch.setattr(cli, "load_env", lambda: None)
+    monkeypatch.setattr(cli, "SESSIONS_DB", tmp_path / "sessions.db")
+
+    # Disable export only in this test; production tracing behavior is unchanged.
+    previous_provider = get_trace_provider()
+    provider = DefaultTraceProvider()
+    provider.set_disabled(True)
+    set_trace_provider(provider)
+    try:
+        cli.main()
+        assert sorted(executed) == [3980, 4127]
+        assert model.calls == 2
+        output = capsys.readouterr().out
+        if debug:
+            assert (
+                "  [tool] lookup({'order_id': 4127})\n"
+                "    -> {'eligible': True}\n"
+                "  [tool] lookup({'order_id': 3980})\n"
+                "    -> {'eligible': False}\n"
+            ) in output
+        else:
+            assert "[tool]" not in output
+        assert "agent> Done." in output
+    finally:
+        set_trace_provider(previous_provider)
+        provider.shutdown()

--- a/tests/test_hw_holes.py
+++ b/tests/test_hw_holes.py
@@ -147,7 +147,7 @@ def test_hw1_find_order(world: dict) -> None:
     result = tools.find_order(SHOPPER_1, product_name)
     assert result["ok"] is True
     assert isinstance(result["orders"], list)
-    assert any(o["id"] == 4127 for o in result["orders"])
+    assert any(o["order_id"] == 4127 for o in result["orders"])
 
     # No match returns an empty list, not an error.
     empty = tools.find_order(SHOPPER_1, "zzzznonexistent9999")


### PR DESCRIPTION
HW1 asks students to record tool arguments and results, but the CLI displays only the final answer. Add `--debug` to show actual SDK tool calls paired with their results, and document its use in Part B. Also correct the supplied `find_order` test to expect `order_id`, matching the existing order schema.

Extracts the HW1 usability fixes from #2. Application tracing behavior is unchanged; the tracing fix remains in that PR. The new CLI tests run in the offline CI job without API keys.

Validation:

- Full offline suite: 81 passed, 12 skipped, 27 expected failures, compared with 79 passed and identical skip/expected-failure counts on the base.
- The two CLI tests and eight independent cases passed. Coverage includes reversed tool completion order, correct result pairing, multi-turn history, debug on/off, and turns without tool calls.
- Three live CLI smoke cases passed: two authorized order lookups with debug output, a cross-store permission denial with debug output, and an authorized lookup without debug output. The course database stayed unchanged.
- The CLI tests passed with provider keys removed. Workflow YAML and `git diff --check` passed.

The existing complete-evaluations CI failure at the unfinished Homework 6 leakage function is outside this change.
