### PR TITLE
fix: make CLI trace uploads opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The starter contains unfinished homework functions. Tests for unfinished functio
 uv run python -m agent.cli --role shopper --user 1
 ```
 
+CLI tracing is off by default. Add `--debug` to print tool calls and results locally. To send traces to OpenAI, add `--trace-openai` and set `OPENAI_API_KEY`; OpenAI hosted tracing is unavailable for zero-data-retention organizations. For the course's Langfuse setup, use `--trace` instead. The two tracing flags cannot be combined. `OPENAI_AGENTS_DISABLE_TRACING=1` disables SDK tracing for either destination.
+
 The default development seed is the executable course world: 20 stores, 800
 products, 525 users, 10,000 orders, and 18 policy documents. The seed script
 is deterministic. Two runs produce identical data, and the

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -27,7 +27,7 @@ import asyncio
 import json
 import time
 
-from agents import Runner, SQLiteSession
+from agents import RunConfig, Runner, SQLiteSession
 from agents.items import RunItem
 from opentelemetry import trace
 
@@ -90,9 +90,15 @@ def resolve_auth(role: str, user_id: int | None) -> AuthContext:
 
 
 async def chat(
-    ctx: AuthContext, model: str | None, defenses: bool = False, debug: bool = False
+    ctx: AuthContext,
+    model: str | None,
+    defenses: bool = False,
+    debug: bool = False,
+    tracing: bool = False,
 ) -> None:
     agent = build_agent(ctx, model=model, defenses=defenses)
+    # Enable SDK callbacks only after main() installs the Langfuse processor.
+    run_config = RunConfig(tracing_disabled=not tracing)
     session = SQLiteSession(
         f"cli-{ctx.role}-{ctx.user_id}-{int(time.time())}", str(SESSIONS_DB)
     )
@@ -118,7 +124,12 @@ async def chat(
                 span.set_attribute("cartwheel.user_id", str(ctx.user_id))
                 span.set_attribute("cartwheel.prompt_version", version)
             result = await Runner.run(
-                agent, line, session=session, context=ctx, max_turns=MAX_TURNS
+                agent,
+                line,
+                session=session,
+                context=ctx,
+                max_turns=MAX_TURNS,
+                run_config=run_config,
             )
 
         # ------------------------------------------------------------------
@@ -140,7 +151,7 @@ async def chat(
         #       # pending call, including its JSON arguments.
         #       state.approve(item)                  # or state.reject(item)
         #   result = await Runner.run(agent, state, context=ctx,
-        #                             max_turns=MAX_TURNS)
+        #                             max_turns=MAX_TURNS, run_config=run_config)
         #
         # Loop until result.interruptions is empty (a resumed run can pause
         # again). Then fall through to printing final_output. Approving here
@@ -186,10 +197,11 @@ def main() -> None:
     args = parser.parse_args()
 
     load_env()
-    if args.trace:
-        setup_tracing()
+    tracing = setup_tracing() if args.trace else False
     ctx = resolve_auth(args.role, args.user)
-    asyncio.run(chat(ctx, args.model, defenses=args.defenses, debug=args.debug))
+    asyncio.run(
+        chat(ctx, args.model, defenses=args.defenses, debug=args.debug, tracing=tracing)
+    )
 
 
 if __name__ == "__main__":

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -9,6 +9,11 @@ Usage:
     uv run python -m agent.cli --role support --user 9502 --trace
     uv run python -m agent.cli --role support --defenses   # Module 4 guards + refund pause
 
+Tracing is off by default. ``--trace`` uses the course's Langfuse setup;
+``--trace-openai`` opts into OpenAI hosted tracing (requires OPENAI_API_KEY
+and is unavailable for zero-data-retention organizations). Pick one destination.
+``--debug`` prints tool calls locally and works independently of tracing.
+
 The role picks a default demo user (shopper 1, merchant 9001, support 9501);
 --user overrides it. The auth context comes from the users table, exactly as
 the server would inject it. It is never taken from the chat itself.
@@ -97,7 +102,7 @@ async def chat(
     tracing: bool = False,
 ) -> None:
     agent = build_agent(ctx, model=model, defenses=defenses)
-    # Enable SDK callbacks only after main() installs the Langfuse processor.
+    # main() enables callbacks for Langfuse or explicit OpenAI tracing.
     run_config = RunConfig(tracing_disabled=not tracing)
     session = SQLiteSession(
         f"cli-{ctx.role}-{ctx.user_id}-{int(time.time())}", str(SESSIONS_DB)
@@ -181,8 +186,13 @@ def main() -> None:
         default=None,
         help="gpt-5.5 | claude-opus-4-6 | glm-5.2 (default: $CARTWHEEL_MODEL or gpt-5.5)",
     )
-    parser.add_argument(
+    tracing_options = parser.add_mutually_exclusive_group()
+    tracing_options.add_argument(
         "--trace", action="store_true", help="ship spans to Langfuse (Lecture 2)"
+    )
+    tracing_options.add_argument(
+        "--trace-openai", action="store_true",
+        help="send traces to OpenAI (unavailable for zero-data-retention organizations)",
     )
     parser.add_argument(
         "--defenses",
@@ -197,7 +207,7 @@ def main() -> None:
     args = parser.parse_args()
 
     load_env()
-    tracing = setup_tracing() if args.trace else False
+    tracing = setup_tracing() if args.trace else args.trace_openai
     ctx = resolve_auth(args.role, args.user)
     asyncio.run(
         chat(ctx, args.model, defenses=args.defenses, debug=args.debug, tracing=tracing)

--- a/observability/instrument.py
+++ b/observability/instrument.py
@@ -62,21 +62,28 @@ def load_env(path: Path | None = None) -> None:
             os.environ.setdefault(key, value)
 
 
-def setup_tracing() -> None:
-    """Instrument the Agents SDK and ship spans to self-hosted Langfuse."""
+def setup_tracing() -> bool:
+    """Install Langfuse tracing; return False when credentials are missing."""
     load_env()
-    if not os.environ.get("LANGFUSE_PUBLIC_KEY"):
+    missing = [
+        key
+        for key in ("LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY")
+        if not os.environ.get(key)
+    ]
+    if missing:
         log.warning(
-            "LANGFUSE_PUBLIC_KEY is not set; tracing is off. Start the stack "
+            "%s is not set; tracing is off. Start the stack "
             "(docker compose -f observability/docker-compose.yml up -d) and "
-            "copy .env.example to .env."
+            "copy .env.example to .env.",
+            ", ".join(missing),
         )
-        return
+        return False
     from langfuse import get_client
 
     get_client()  # registers the OTel tracer provider from LANGFUSE_* env vars
     instrument_genai(trace.get_tracer_provider())
     log.info("tracing enabled; spans go to %s", os.environ.get("LANGFUSE_HOST"))
+    return True
 
 
 def record_tool_result(ctx: "AuthContext", result: dict[str, Any]) -> None:

--- a/observability/instrument.py
+++ b/observability/instrument.py
@@ -72,7 +72,7 @@ def setup_tracing() -> bool:
     ]
     if missing:
         log.warning(
-            "%s is not set; tracing is off. Start the stack "
+            "Missing %s; tracing is off. Start the stack "
             "(docker compose -f observability/docker-compose.yml up -d) and "
             "copy .env.example to .env.",
             ", ".join(missing),

--- a/observability/instrument.py
+++ b/observability/instrument.py
@@ -37,9 +37,10 @@ def instrument_genai(tracer_provider: Any) -> None:
 
     os.environ.setdefault("TRACELOOP_TRACE_CONTENT", "false")
     # Export only through Langfuse, not the SDK's separate hosted tracing path.
-    OpenAIAgentsInstrumentor(replace_existing_processors=True).instrument(
-        tracer_provider=tracer_provider
-    )
+    instrumentor = OpenAIAgentsInstrumentor(replace_existing_processors=True)
+    instrumentor.instrument(tracer_provider=tracer_provider)
+    if not instrumentor.is_instrumented_by_opentelemetry:
+        raise RuntimeError("OpenAI Agents tracing instrumentation failed to install")
     _genai_instrumented = True
 
 
@@ -65,23 +66,22 @@ def load_env(path: Path | None = None) -> None:
 def setup_tracing() -> bool:
     """Install Langfuse tracing; return False when credentials are missing."""
     load_env()
-    missing = [
-        key
-        for key in ("LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY")
-        if not os.environ.get(key)
-    ]
-    if missing:
+    if not os.environ.get("LANGFUSE_PUBLIC_KEY"):
         log.warning(
-            "Missing %s; tracing is off. Start the stack "
+            "LANGFUSE_PUBLIC_KEY is not set; tracing is off. Start the stack "
             "(docker compose -f observability/docker-compose.yml up -d) and "
-            "copy .env.example to .env.",
-            ", ".join(missing),
+            "copy .env.example to .env."
         )
         return False
     from langfuse import get_client
 
     get_client()  # registers the OTel tracer provider from LANGFUSE_* env vars
     instrument_genai(trace.get_tracer_provider())
+    # Preserve processor replacement for callers such as the server, which
+    # ignore our return value. A missing secret makes Langfuse a no-op client;
+    # returning before replacement would leave hosted OpenAI export active.
+    if not os.environ.get("LANGFUSE_SECRET_KEY"):
+        return False
     log.info("tracing enabled; spans go to %s", os.environ.get("LANGFUSE_HOST"))
     return True
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from unittest.mock import create_autospec
 from typing import Any
 
 import httpx
@@ -13,7 +12,7 @@ import pytest
 from agents import Agent, function_tool
 from agents.items import ModelResponse
 from agents.models.interface import Model
-from agents.tracing import TracingProcessor, get_trace_provider, set_trace_provider, trace
+from agents.tracing import get_trace_provider, set_trace_provider, trace
 from agents.tracing.processors import BackendSpanExporter, BatchTraceProcessor
 from agents.tracing.provider import DefaultTraceProvider
 from agents.usage import Usage
@@ -22,7 +21,6 @@ from openai.types.responses import (
     ResponseOutputMessage,
     ResponseOutputText,
 )
-
 from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
 from opentelemetry.trace import NoOpTracerProvider
 from opentelemetry.sdk.trace import TracerProvider
@@ -69,9 +67,41 @@ class ScriptedModel(Model):
         yield
 
 
+@pytest.fixture
+def hosted_exports(monkeypatch):
+    """Isolate SDK tracing and capture hosted exports without network calls."""
+    monkeypatch.setattr(instrument, "load_env", lambda: None)
+    monkeypatch.setattr(instrument, "_genai_instrumented", False)
+    requests = []
+
+    def reject_export(request):
+        requests.append(request)
+        return httpx.Response(403, text="simulated ZDR tracing rejection")
+
+    exporter = BackendSpanExporter(api_key="offline-placeholder")
+    exporter._client.close()
+    exporter._client = httpx.Client(transport=httpx.MockTransport(reject_export))
+    hosted_processor = BatchTraceProcessor(exporter)
+    previous_provider = get_trace_provider()
+    provider = DefaultTraceProvider()
+    provider.set_disabled(False)
+    provider.register_processor(hosted_processor)
+    set_trace_provider(provider)
+    try:
+        yield hosted_processor, requests
+    finally:
+        instrumentor = OpenAIAgentsInstrumentor()
+        if instrumentor.is_instrumented_by_opentelemetry:
+            instrumentor.uninstrument()
+        set_trace_provider(previous_provider)
+        provider.shutdown()
+        hosted_processor.shutdown()
+        exporter._client.close()
+
+
 @pytest.mark.parametrize("debug", [False, True])
 @pytest.mark.parametrize("tracing", ["plain", "missing_public", "missing_secret", "configured", "openai"])
-def test_cli_tool_results(debug, tracing, tmp_path, monkeypatch, capsys, caplog) -> None:
+def test_cli_tool_results(debug, tracing, tmp_path, monkeypatch, capsys, caplog, hosted_exports) -> None:
     executed = []
 
     @function_tool
@@ -96,8 +126,6 @@ def test_cli_tool_results(debug, tracing, tmp_path, monkeypatch, capsys, caplog)
     monkeypatch.setattr(cli, "SESSIONS_DB", tmp_path / "sessions.db")
 
     # Use the real setup and processor replacement with a local OTel sink.
-    monkeypatch.setattr(instrument, "load_env", lambda: None)
-    monkeypatch.setattr(instrument, "_genai_instrumented", False)
     monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "offline-public")
     monkeypatch.setenv("LANGFUSE_SECRET_KEY", "offline-secret")
     if tracing == "missing_public":
@@ -112,22 +140,7 @@ def test_cli_tool_results(debug, tracing, tmp_path, monkeypatch, capsys, caplog)
     selected_provider = NoOpTracerProvider() if tracing == "missing_secret" else otel_provider
     monkeypatch.setattr(instrument.trace, "get_tracer_provider", lambda: selected_provider)
 
-    # A hosted export would fail for ZDR. Capture it without contacting OpenAI.
-    requests = []
-
-    def reject_export(request):
-        requests.append(request)
-        return httpx.Response(403, text="simulated ZDR tracing rejection")
-
-    exporter = BackendSpanExporter(api_key="offline-placeholder")
-    exporter._client.close()
-    exporter._client = httpx.Client(transport=httpx.MockTransport(reject_export))
-    hosted_processor = BatchTraceProcessor(exporter)
-    previous_provider = get_trace_provider()
-    provider = DefaultTraceProvider()
-    provider.set_disabled(False)
-    provider.register_processor(hosted_processor)
-    set_trace_provider(provider)
+    hosted_processor, requests = hosted_exports
     try:
         cli.main()
         assert sorted(executed) == [3980, 4127]
@@ -146,11 +159,10 @@ def test_cli_tool_results(debug, tracing, tmp_path, monkeypatch, capsys, caplog)
         hosted_processor.force_flush()
         assert len(requests) == int(tracing == "openai")
         spans = otel_exporter.get_finished_spans()
+        assert setup_calls == ([True] if tracing in {"configured", "missing_secret"} else [])
         if tracing == "configured":
-            assert setup_calls == [True]
             assert sum(span.name == "lookup.tool" for span in spans) == 2
         else:
-            assert setup_calls == ([True] if tracing == "missing_secret" else [])
             assert spans == ()
         if tracing == "missing_public":
             assert "tracing is off" in caplog.text
@@ -161,12 +173,6 @@ def test_cli_tool_results(debug, tracing, tmp_path, monkeypatch, capsys, caplog)
         expected = 0 if tracing in {"configured", "missing_secret"} else 1
         assert len(requests) == expected + int(tracing == "openai")
     finally:
-        if tracing in {"configured", "missing_secret"}:
-            OpenAIAgentsInstrumentor().uninstrument()
-        set_trace_provider(previous_provider)
-        provider.shutdown()
-        hosted_processor.shutdown()
-        exporter._client.close()
         otel_provider.shutdown()
 
 
@@ -177,35 +183,23 @@ def test_trace_destinations_are_mutually_exclusive(monkeypatch) -> None:
     assert exc.value.code == 2
 
 
-def test_server_missing_secret_still_replaces_hosted_exporter(monkeypatch) -> None:
+def test_server_missing_secret_still_replaces_hosted_exporter(monkeypatch, hosted_exports) -> None:
     from server import app as server
 
     monkeypatch.setattr(server, "load_env", lambda: None)
-    monkeypatch.setattr(instrument, "load_env", lambda: None)
-    monkeypatch.setattr(instrument, "_genai_instrumented", False)
     monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "offline-public-server")
     monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
     # Use real Langfuse initialization: absent secret creates a no-op client.
-    previous_provider = get_trace_provider()
-    provider = DefaultTraceProvider()
-    provider.set_disabled(False)
-    hosted = create_autospec(TracingProcessor, instance=True)
-    provider.register_processor(hosted)
-    set_trace_provider(provider)
+    hosted_processor, requests = hosted_exports
 
     async def run() -> None:
         async with server.lifespan(server.app):
             with trace("student-completed-server-run"):
                 pass
 
-    try:
-        asyncio.run(run())
-        hosted.on_trace_start.assert_not_called()
-        hosted.on_trace_end.assert_not_called()
-    finally:
-        OpenAIAgentsInstrumentor().uninstrument()
-        set_trace_provider(previous_provider)
-        provider.shutdown()
+    asyncio.run(run())
+    hosted_processor.force_flush()
+    assert requests == []
 
 
 def test_instrumentation_failure_does_not_report_success(monkeypatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import json
 from typing import Any
 
+import httpx
+import langfuse
 import pytest
 from agents import Agent, function_tool
 from agents.items import ModelResponse
 from agents.models.interface import Model
-from agents.tracing import get_trace_provider, set_trace_provider
+from agents.tracing import get_trace_provider, set_trace_provider, trace
+from agents.tracing.processors import BackendSpanExporter, BatchTraceProcessor
 from agents.tracing.provider import DefaultTraceProvider
 from agents.usage import Usage
 from openai.types.responses import (
@@ -18,8 +21,14 @@ from openai.types.responses import (
     ResponseOutputText,
 )
 
+from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
 from agent import cli
 from agent.auth import AuthContext
+from observability import instrument
 
 
 class ScriptedModel(Model):
@@ -58,7 +67,8 @@ class ScriptedModel(Model):
 
 
 @pytest.mark.parametrize("debug", [False, True])
-def test_cli_tool_results(debug, tmp_path, monkeypatch, capsys) -> None:
+@pytest.mark.parametrize("tracing", ["plain", "missing_public", "missing_secret", "configured"])
+def test_cli_tool_results(debug, tracing, tmp_path, monkeypatch, capsys, caplog) -> None:
     executed = []
 
     @function_tool
@@ -70,17 +80,47 @@ def test_cli_tool_results(debug, tmp_path, monkeypatch, capsys) -> None:
     agent = Agent(name="offline-cli", model=model, tools=[lookup])
     ctx = AuthContext(user_id=1, role="shopper")
     messages = iter(["Check both orders", "quit"])
-    monkeypatch.setattr("sys.argv", ["agent.cli"] + (["--debug"] if debug else []))
+    argv = ["agent.cli"] + (["--debug"] if debug else [])
+    if tracing != "plain":
+        argv.append("--trace")
+    monkeypatch.setattr("sys.argv", argv)
     monkeypatch.setattr("builtins.input", lambda _: next(messages))
     monkeypatch.setattr(cli, "build_agent", lambda *args, **kwargs: agent)
     monkeypatch.setattr(cli, "resolve_auth", lambda *args: ctx)
     monkeypatch.setattr(cli, "load_env", lambda: None)
     monkeypatch.setattr(cli, "SESSIONS_DB", tmp_path / "sessions.db")
 
-    # Disable export only in this test; production tracing behavior is unchanged.
+    # Use the real setup and processor replacement with a local OTel sink.
+    monkeypatch.setattr(instrument, "load_env", lambda: None)
+    monkeypatch.setattr(instrument, "_genai_instrumented", False)
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "offline-public")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "offline-secret")
+    if tracing == "missing_public":
+        monkeypatch.delenv("LANGFUSE_PUBLIC_KEY")
+    elif tracing == "missing_secret":
+        monkeypatch.delenv("LANGFUSE_SECRET_KEY")
+    otel_provider = TracerProvider()
+    otel_exporter = InMemorySpanExporter()
+    otel_provider.add_span_processor(SimpleSpanProcessor(otel_exporter))
+    setup_calls = []
+    monkeypatch.setattr(langfuse, "get_client", lambda: setup_calls.append(True))
+    monkeypatch.setattr(instrument.trace, "get_tracer_provider", lambda: otel_provider)
+
+    # A hosted export would fail for ZDR. Capture it without contacting OpenAI.
+    requests = []
+
+    def reject_export(request):
+        requests.append(request)
+        return httpx.Response(403, text="simulated ZDR tracing rejection")
+
+    exporter = BackendSpanExporter(api_key="offline-placeholder")
+    exporter._client.close()
+    exporter._client = httpx.Client(transport=httpx.MockTransport(reject_export))
+    hosted_processor = BatchTraceProcessor(exporter)
     previous_provider = get_trace_provider()
     provider = DefaultTraceProvider()
-    provider.set_disabled(True)
+    provider.set_disabled(False)
+    provider.register_processor(hosted_processor)
     set_trace_provider(provider)
     try:
         cli.main()
@@ -97,6 +137,27 @@ def test_cli_tool_results(debug, tmp_path, monkeypatch, capsys) -> None:
         else:
             assert "[tool]" not in output
         assert "agent> Done." in output
+        hosted_processor.force_flush()
+        assert requests == []
+        spans = otel_exporter.get_finished_spans()
+        if tracing == "configured":
+            assert setup_calls == [True]
+            assert sum(span.name == "lookup.tool" for span in spans) == 2
+        else:
+            assert setup_calls == []
+            assert spans == ()
+        if tracing.startswith("missing_"):
+            assert "tracing is off" in caplog.text
+        # Disabling tracing for CLI runs must not disable unrelated SDK traces.
+        with trace("unrelated") as unrelated:
+            assert unrelated.export() is not None
+        hosted_processor.force_flush()
+        assert len(requests) == (0 if tracing == "configured" else 1)
     finally:
+        if tracing == "configured":
+            OpenAIAgentsInstrumentor().uninstrument()
         set_trace_provider(previous_provider)
         provider.shutdown()
+        hosted_processor.shutdown()
+        exporter._client.close()
+        otel_provider.shutdown()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+from unittest.mock import create_autospec
 from typing import Any
 
 import httpx
@@ -11,7 +13,7 @@ import pytest
 from agents import Agent, function_tool
 from agents.items import ModelResponse
 from agents.models.interface import Model
-from agents.tracing import get_trace_provider, set_trace_provider, trace
+from agents.tracing import TracingProcessor, get_trace_provider, set_trace_provider, trace
 from agents.tracing.processors import BackendSpanExporter, BatchTraceProcessor
 from agents.tracing.provider import DefaultTraceProvider
 from agents.usage import Usage
@@ -22,6 +24,7 @@ from openai.types.responses import (
 )
 
 from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+from opentelemetry.trace import NoOpTracerProvider
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -67,7 +70,7 @@ class ScriptedModel(Model):
 
 
 @pytest.mark.parametrize("debug", [False, True])
-@pytest.mark.parametrize("tracing", ["plain", "missing_public", "missing_secret", "configured"])
+@pytest.mark.parametrize("tracing", ["plain", "missing_public", "missing_secret", "configured", "openai"])
 def test_cli_tool_results(debug, tracing, tmp_path, monkeypatch, capsys, caplog) -> None:
     executed = []
 
@@ -81,7 +84,9 @@ def test_cli_tool_results(debug, tracing, tmp_path, monkeypatch, capsys, caplog)
     ctx = AuthContext(user_id=1, role="shopper")
     messages = iter(["Check both orders", "quit"])
     argv = ["agent.cli"] + (["--debug"] if debug else [])
-    if tracing != "plain":
+    if tracing == "openai":
+        argv.append("--trace-openai")
+    elif tracing != "plain":
         argv.append("--trace")
     monkeypatch.setattr("sys.argv", argv)
     monkeypatch.setattr("builtins.input", lambda _: next(messages))
@@ -104,7 +109,8 @@ def test_cli_tool_results(debug, tracing, tmp_path, monkeypatch, capsys, caplog)
     otel_provider.add_span_processor(SimpleSpanProcessor(otel_exporter))
     setup_calls = []
     monkeypatch.setattr(langfuse, "get_client", lambda: setup_calls.append(True))
-    monkeypatch.setattr(instrument.trace, "get_tracer_provider", lambda: otel_provider)
+    selected_provider = NoOpTracerProvider() if tracing == "missing_secret" else otel_provider
+    monkeypatch.setattr(instrument.trace, "get_tracer_provider", lambda: selected_provider)
 
     # A hosted export would fail for ZDR. Capture it without contacting OpenAI.
     requests = []
@@ -138,26 +144,76 @@ def test_cli_tool_results(debug, tracing, tmp_path, monkeypatch, capsys, caplog)
             assert "[tool]" not in output
         assert "agent> Done." in output
         hosted_processor.force_flush()
-        assert requests == []
+        assert len(requests) == int(tracing == "openai")
         spans = otel_exporter.get_finished_spans()
         if tracing == "configured":
             assert setup_calls == [True]
             assert sum(span.name == "lookup.tool" for span in spans) == 2
         else:
-            assert setup_calls == []
+            assert setup_calls == ([True] if tracing == "missing_secret" else [])
             assert spans == ()
-        if tracing.startswith("missing_"):
+        if tracing == "missing_public":
             assert "tracing is off" in caplog.text
         # Disabling tracing for CLI runs must not disable unrelated SDK traces.
         with trace("unrelated") as unrelated:
             assert unrelated.export() is not None
         hosted_processor.force_flush()
-        assert len(requests) == (0 if tracing == "configured" else 1)
+        expected = 0 if tracing in {"configured", "missing_secret"} else 1
+        assert len(requests) == expected + int(tracing == "openai")
     finally:
-        if tracing == "configured":
+        if tracing in {"configured", "missing_secret"}:
             OpenAIAgentsInstrumentor().uninstrument()
         set_trace_provider(previous_provider)
         provider.shutdown()
         hosted_processor.shutdown()
         exporter._client.close()
         otel_provider.shutdown()
+
+
+def test_trace_destinations_are_mutually_exclusive(monkeypatch) -> None:
+    monkeypatch.setattr("sys.argv", ["agent.cli", "--trace", "--trace-openai"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 2
+
+
+def test_server_missing_secret_still_replaces_hosted_exporter(monkeypatch) -> None:
+    from server import app as server
+
+    monkeypatch.setattr(server, "load_env", lambda: None)
+    monkeypatch.setattr(instrument, "load_env", lambda: None)
+    monkeypatch.setattr(instrument, "_genai_instrumented", False)
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "offline-public-server")
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+    # Use real Langfuse initialization: absent secret creates a no-op client.
+    previous_provider = get_trace_provider()
+    provider = DefaultTraceProvider()
+    provider.set_disabled(False)
+    hosted = create_autospec(TracingProcessor, instance=True)
+    provider.register_processor(hosted)
+    set_trace_provider(provider)
+
+    async def run() -> None:
+        async with server.lifespan(server.app):
+            with trace("student-completed-server-run"):
+                pass
+
+    try:
+        asyncio.run(run())
+        hosted.on_trace_start.assert_not_called()
+        hosted.on_trace_end.assert_not_called()
+    finally:
+        OpenAIAgentsInstrumentor().uninstrument()
+        set_trace_provider(previous_provider)
+        provider.shutdown()
+
+
+def test_instrumentation_failure_does_not_report_success(monkeypatch) -> None:
+    monkeypatch.setattr(instrument, "_genai_instrumented", False)
+    monkeypatch.setattr(
+        OpenAIAgentsInstrumentor, "_check_dependency_conflicts",
+        lambda self: "simulated dependency conflict",
+    )
+    with pytest.raises(RuntimeError, match="failed to install"):
+        instrument.instrument_genai(NoOpTracerProvider())
+    assert instrument._genai_instrumented is False


### PR DESCRIPTION
Plain CLI conversations currently trigger the Agents SDK's default OpenAI trace exporter. For students using a zero-data-retention organization, those exports fail and print errors even though the conversation succeeds.

Disable SDK tracing per CLI run by default. Students can explicitly choose `--trace-openai` for hosted OpenAI traces or `--trace` for the course's Langfuse setup. The flags are mutually exclusive, both respect the SDK tracing-disable environment variable, and `--debug` works independently. The README explains these choices.

Langfuse setup returns a boolean for the CLI to consume. Missing credentials leave CLI tracing disabled. With a public key but no secret, preserve the existing processor replacement before returning False, so server callers that ignore the return value do not resume hosted export. The server's existing behavior when the public key is missing is unchanged. Report instrumentation dependency-check failures instead of claiming successful setup. Preserve the run configuration in the HW8 resume example.

Extracts the tracing fix from #2. The debug output and order-ID changes were merged in #5.

Validation:
- Full suite: 92 passed, 12 skipped, 27 expected failures.
- 13 CLI/setup tests cover destination selection, debug on/off, missing credentials, hosted export interception, actual OTel processor replacement, server startup with a missing secret, and instrumentation dependency-check failure. Existing offline CI runs these tests without API keys.
- Additional offline experiments verify two-turn exported payloads and the environment disable switch. Mutation tests rejected five plausible tracing regressions before the follow-up changes.
- Three independent reviews of the final implementation found no actionable introduced defects.
- Live ZDR-account behavior and remote OpenAI/Langfuse delivery were not tested. Upstream instrumentation can swallow internal errors; the new installation check detects dependency refusal, not every possible broken installation.

The existing complete-evaluations job has an unrelated HW6 `find_leaks` placeholder failure.
