### PR TITLE
feat: save HW1 conversation drafts from the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The starter contains unfinished homework functions. Tests for unfinished functio
 uv run python -m agent.cli --role shopper --user 1
 ```
 
+Add `--save hw1-session.jsonl` to save a conversation draft when you exit the CLI. It includes follow-up turns and tool results; add your assessment afterward as described in [Homework 1](homework/module-1/hw1.md).
+
 CLI tracing is off by default. Add `--debug` to print tool calls and results locally. To send traces to OpenAI, add `--trace-openai` and set `OPENAI_API_KEY`; OpenAI hosted tracing is unavailable for zero-data-retention organizations. For the course's Langfuse setup, use `--trace` instead. The two tracing flags cannot be combined. `OPENAI_AGENTS_DISABLE_TRACING=1` disables SDK tracing for either destination.
 
 The default development seed is the executable course world: 20 stores, 800

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -13,6 +13,9 @@ Tracing is off by default. ``--trace`` uses the course's Langfuse setup;
 ``--trace-openai`` opts into OpenAI hosted tracing (requires OPENAI_API_KEY
 and is unavailable for zero-data-retention organizations). Pick one destination.
 ``--debug`` prints tool calls locally and works independently of tracing.
+``--save PATH`` appends one conversation draft on exit, including follow-up
+turns. Recording is local and does not require tracing. Add your assessment
+to the saved draft afterward.
 
 The role picks a default demo user (shopper 1, merchant 9001, support 9501);
 --user overrides it. The auth context comes from the users table, exactly as
@@ -30,7 +33,10 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
-import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import uuid4
 
 from agents import RunConfig, Runner, SQLiteSession
 from agents.items import RunItem
@@ -48,18 +54,14 @@ SESSIONS_DB = REPO_ROOT / ".sessions.db"
 _tracer = trace.get_tracer("cartwheel.cli")
 
 
-def _print_tool_calls(new_items: list[RunItem]) -> None:
-    """Print each tool call and its result from one run's new items.
-
-    `Runner.run` always returns the tool calls and their outputs on
-    `result.new_items`, independent of whether tracing is configured, so
-    this is accurate with or without --trace.
-    """
+def _tool_calls(new_items: list[RunItem]) -> list[dict[str, Any]]:
+    """Pair this turn's function calls and results by call ID."""
     outputs = {
         item.call_id: item.output
         for item in new_items
         if item.type == "tool_call_output_item" and item.call_id is not None
     }
+    calls = []
     for item in new_items:
         if item.type == "tool_call_item":
             raw = item.raw_item
@@ -73,9 +75,47 @@ def _print_tool_calls(new_items: list[RunItem]) -> None:
                     args = json.loads(args)
                 except json.JSONDecodeError:
                     pass
-            print(f"  [tool] {item.tool_name}({args})")
+            call = {"name": item.tool_name, "arguments": args}
             if item.call_id in outputs:
-                print(f"    -> {outputs[item.call_id]}")
+                call["result"] = outputs[item.call_id]
+            calls.append(call)
+    return calls
+
+
+@contextmanager
+def _record_conversation(path: Path | None, ctx: AuthContext) -> Iterator[dict[str, Any]]:
+    """Append one factual draft, preserving completed turns if a later run fails."""
+    record: dict[str, Any] = {"turns": [], "pending_request": None}
+    if path is None:
+        yield record
+        return
+    # Open before any model calls so an unwritable destination fails early.
+    with path.open("a+b") as output:
+        separator = b""
+        if output.tell():
+            output.seek(-1, 2)
+            if output.read(1) != b"\n":
+                separator = b"\n"
+        complete = False
+        try:
+            yield record
+            complete = True
+        finally:
+            turns = record["turns"]
+            if turns or record["pending_request"] is not None:
+                record.update(
+                    role=ctx.role, user_id=ctx.user_id, store_id=ctx.store_id,
+                    request=turns[0]["request"] if turns else record["pending_request"],
+                    response=turns[-1]["response"] if turns else None,
+                    tool_calls=[call for turn in turns for call in turn["tool_calls"]],
+                    expected=None, requirement=None, met_requirement=None, problem_source=None,
+                    execution_complete=complete,
+                )
+                output.write(separator + json.dumps(record, ensure_ascii=False).encode("utf-8") + b"\n")
+                if complete:
+                    print(f"Conversation saved to {path}. Add your assessment to complete the record.")
+                else:
+                    print(f"Incomplete conversation saved to {path}; pending tool activity may be missing.")
 
 
 def resolve_auth(role: str, user_id: int | None) -> AuthContext:
@@ -100,12 +140,13 @@ async def chat(
     defenses: bool = False,
     debug: bool = False,
     tracing: bool = False,
+    save: Path | None = None,
 ) -> None:
     agent = build_agent(ctx, model=model, defenses=defenses)
     # main() enables callbacks for Langfuse or explicit OpenAI tracing.
     run_config = RunConfig(tracing_disabled=not tracing)
     session = SQLiteSession(
-        f"cli-{ctx.role}-{ctx.user_id}-{int(time.time())}", str(SESSIONS_DB)
+        f"cli-{ctx.role}-{ctx.user_id}-{uuid4().hex}", str(SESSIONS_DB)
     )
     version = prompt_version(render_system_prompt(ctx))
     print(
@@ -113,68 +154,79 @@ async def chat(
         f"store={ctx.store_id} prompt_version={version} defenses={'on' if defenses else 'off'}"
     )
     print("Type a message, or 'quit' to exit.\n")
-    while True:
-        try:
-            line = input(f"{ctx.role}> ").strip()
-        except (EOFError, KeyboardInterrupt):
-            print()
-            return
-        if not line:
-            continue
-        if line.lower() in {"quit", "exit"}:
-            return
-        with _tracer.start_as_current_span("cartwheel.session_message") as span:
-            if span.is_recording():
-                span.set_attribute("cartwheel.user_role", ctx.role)
-                span.set_attribute("cartwheel.user_id", str(ctx.user_id))
-                span.set_attribute("cartwheel.prompt_version", version)
-            result = await Runner.run(
-                agent,
-                line,
-                session=session,
-                context=ctx,
-                max_turns=MAX_TURNS,
-                run_config=run_config,
-            )
+    with _record_conversation(save, ctx) as record:
+        while True:
+            try:
+                line = input(f"{ctx.role}> ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                return
+            if not line:
+                continue
+            if line.lower() in {"quit", "exit"}:
+                return
+            record["pending_request"] = line
+            with _tracer.start_as_current_span("cartwheel.session_message") as span:
+                if span.is_recording():
+                    span.set_attribute("cartwheel.user_role", ctx.role)
+                    span.set_attribute("cartwheel.user_id", str(ctx.user_id))
+                    span.set_attribute("cartwheel.prompt_version", version)
+                result = await Runner.run(
+                    agent,
+                    line,
+                    session=session,
+                    context=ctx,
+                    max_turns=MAX_TURNS,
+                    run_config=run_config,
+                )
 
-        # ------------------------------------------------------------------
-        # Module 4 pause and resume code (Homework 8, Part D). With defenses on,
-        # an above-threshold refund makes refund_needs_human return True, so
-        # the SDK pauses the run instead of executing the tool and lists the
-        # pending call(s) in result.interruptions (each a ToolApprovalItem).
-        # A queued run is not finished: result.final_output is not the answer
-        # until the interruptions are resolved and the run resumes.
-        #
-        # Your job (the seam below): while result has interruptions, show each
-        # pending tool name and its arguments, ask whether the tool may run,
-        # save the answer in a resumable state, and resume the run. The SDK
-        # contract (verified, openai-agents 0.17.7):
-        #
-        #   state = result.to_state()
-        #   for item in result.interruptions:        # ToolApprovalItem
-        #       # item.tool_name names the tool. item.raw_item carries the
-        #       # pending call, including its JSON arguments.
-        #       state.approve(item)                  # or state.reject(item)
-        #   result = await Runner.run(agent, state, context=ctx,
-        #                             max_turns=MAX_TURNS, run_config=run_config)
-        #
-        # Loop until result.interruptions is empty (a resumed run can pause
-        # again). Then fall through to printing final_output. Approving here
-        # only allows the tool to run. The tool may then create a refund with
-        # status queued_for_approval. A support user makes the later refund
-        # decision through agent/review.py.
-        # ------------------------------------------------------------------
-        if getattr(result, "interruptions", None):
-            ### YOUR CODE HERE (m4)
-            raise NotImplementedError(
-                "m4: show each pending tool call, allow or reject it via "
-                "result.to_state(), and resume with Runner.run(agent, state, ...). "
-                "See the seam comment above."
-            )
+            # ------------------------------------------------------------------
+            # Module 4 pause and resume code (Homework 8, Part D). With defenses on,
+            # an above-threshold refund makes refund_needs_human return True, so
+            # the SDK pauses the run instead of executing the tool and lists the
+            # pending call(s) in result.interruptions (each a ToolApprovalItem).
+            # A queued run is not finished: result.final_output is not the answer
+            # until the interruptions are resolved and the run resumes.
+            #
+            # Your job (the seam below): while result has interruptions, show each
+            # pending tool name and its arguments, ask whether the tool may run,
+            # save the answer in a resumable state, and resume the run. The SDK
+            # contract (verified, openai-agents 0.17.7):
+            #
+            #   state = result.to_state()
+            #   for item in result.interruptions:        # ToolApprovalItem
+            #       # item.tool_name names the tool. item.raw_item carries the
+            #       # pending call, including its JSON arguments.
+            #       state.approve(item)                  # or state.reject(item)
+            #   result = await Runner.run(agent, state, context=ctx,
+            #                             max_turns=MAX_TURNS, run_config=run_config)
+            #
+            # Loop until result.interruptions is empty (a resumed run can pause
+            # again). Then fall through to printing final_output. Approving here
+            # only allows the tool to run. The tool may then create a refund with
+            # status queued_for_approval. A support user makes the later refund
+            # decision through agent/review.py.
+            # ------------------------------------------------------------------
+            if getattr(result, "interruptions", None):
+                ### YOUR CODE HERE (m4)
+                raise NotImplementedError(
+                    "m4: show each pending tool call, allow or reject it via "
+                    "result.to_state(), and resume with Runner.run(agent, state, ...). "
+                    "See the seam comment above."
+                )
 
-        if debug:
-            _print_tool_calls(result.new_items)
-        print(f"\nagent> {result.final_output}\n")
+            calls = _tool_calls(result.new_items) if debug or save is not None else []
+            if save is not None:
+                record["turns"].append({
+                    "request": line, "tool_calls": calls, "response": result.final_output,
+                })
+            record["pending_request"] = None
+            if debug:
+                for call in calls:
+                    print(f"  [tool] {call['name']}({call['arguments']})")
+                    if "result" in call:
+                        print(f"    -> {call['result']}")
+            print(f"\nagent> {result.final_output}\n")
 
 
 def main() -> None:
@@ -204,13 +256,17 @@ def main() -> None:
         action="store_true",
         help="print each tool call's name, arguments, and result",
     )
+    parser.add_argument(
+        "--save", type=Path, metavar="PATH",
+        help="append one conversation draft on exit; add your own assessment afterward",
+    )
     args = parser.parse_args()
 
     load_env()
     tracing = setup_tracing() if args.trace else args.trace_openai
     ctx = resolve_auth(args.role, args.user)
     asyncio.run(
-        chat(ctx, args.model, defenses=args.defenses, debug=args.debug, tracing=tracing)
+        chat(ctx, args.model, defenses=args.defenses, debug=args.debug, tracing=tracing, save=args.save)
     )
 
 

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -112,6 +112,7 @@ def _record_conversation(path: Path | None, ctx: AuthContext) -> Iterator[dict[s
                     execution_complete=complete,
                 )
                 output.write(separator + json.dumps(record, ensure_ascii=False).encode("utf-8") + b"\n")
+                output.flush()
                 if complete:
                     print(f"Conversation saved to {path}. Add your assessment to complete the record.")
                 else:

--- a/homework/module-1/hw1.md
+++ b/homework/module-1/hw1.md
@@ -123,37 +123,59 @@ The required order cases depend on permissions stored in the local database. Use
 Use the command that matches the identity you want to test:
 
 ```bash
-uv run python -m agent.cli --role shopper --user 1
-uv run python -m agent.cli --role merchant --user 9002
-uv run python -m agent.cli --role support --user 9501
+uv run python -m agent.cli --role shopper --user 1 --save hw1-session.jsonl
+uv run python -m agent.cli --role merchant --user 9002 --save hw1-session.jsonl
+uv run python -m agent.cli --role support --user 9501 --save hw1-session.jsonl
 ```
 
 The commands select the authenticated identity, but they do not determine the request.
 
-Add `--debug` to print each tool call's name, arguments, and result after each
-turn finishes. Use this output to fill in `tool_calls` in `hw1-session.jsonl`.
-This works without Langfuse or the Homework 2 tracing setup. For example:
+`--save` appends one conversation draft to `hw1-session.jsonl` when you quit,
+press Ctrl-C at the input prompt, or reach the end of input. Keep follow-up
+turns in the same CLI session; quit and restart for a separate conversation.
+Existing records are preserved. Without `--save`, the CLI does not write this file.
+
+The draft contains your authenticated identity, requests, tool calls and results,
+and responses. Add your own `expected`, `requirement`, `met_requirement`, and
+`problem_source` values afterward. These start as `null`; an unreviewed draft
+does not count as a completed homework record.
+
+Add `--debug` if you also want to see the tool calls in the terminal. Both
+options work without Langfuse or the Homework 2 tracing setup. For example:
 
 ```bash
-uv run python -m agent.cli --role shopper --user 1 --debug
+uv run python -m agent.cli --role shopper --user 1 --save hw1-session.jsonl --debug
 ```
 
 Add four more conversations after reading `SPEC.md`. Here is the first case to add: as shopper user `1`, ask, "Can you change the email address on my Cartwheel account to new@example.com?" Determine the expected behavior from `SPEC.md`, then compare the expected behavior with the agent's response. Design the remaining three conversations yourself, including the role, user, and request for each conversation.
 
 A refund or cancellation changes the local database. If you want to test another conversation against the original order state, run `uv run python -m seed.generate` before starting the next conversation. Keep the same database state throughout a conversation you are recording.
 
-Write each conversation as one line of `hw1-session.jsonl`. Each record must contain:
+Review each saved conversation in `hw1-session.jsonl`. Each completed record must contain:
 
 - `role`, the authenticated role.
 - `user_id`, the authenticated user's identifier.
 - `store_id`, the authenticated merchant's store, or `null` for other roles.
-- `request`, the user's request.
+- `request`, the initial user request.
 - `tool_calls`, a list containing each tool name, its arguments, and its result. Use an empty list when the agent called no tools.
-- `response`, the agent's final response.
+- `response`, the agent's final response to the last turn.
 - `expected`, the behavior implied by the current specification.
 - `requirement`, the identifier of the relevant requirement in `SPEC.md`, or `null` when no single requirement applies.
 - `met_requirement`, `true` when the observed behavior met the requirement, and `false` when it did not.
 - `problem_source`, either `prompt`, `tool`, `specification`, or `null`. Use `null` when the agent met the requirement.
+
+The recorder also saves `turns`, an ordered list of requests, tool calls, and
+responses. For a multi-turn conversation, use this full sequence when reviewing
+behavior or repeating the case; the top-level `request` is only its first request
+and `tool_calls` combines the completed turns. One saved conversation counts as
+one record, regardless of the number of turns.
+
+`execution_complete: true` means the CLI exited normally, not that your assessment
+is complete. If a run fails or is interrupted, the recorder saves any completed
+turns with `execution_complete: false` and the `pending_request`. Tool activity
+for that pending request may be missing. Keep the partial draft for diagnosis,
+but exclude it from the required ten completed conversations. Saving happens
+on exit; a forced process kill or write failure can prevent it.
 
 Use `prompt` when the tools returned the right information but the model made a poor decision. Use `tool` when a function returned the wrong information or changed the wrong state. Use `specification` when `SPEC.md` does not say what correct behavior would be.
 
@@ -186,6 +208,6 @@ Record one continuous screen video of no more than 5 minutes. In the recording:
 - Show how the agent handles the refund request for order `4455`, including whether it calls the refund tool or opens an escalation.
 - Explain the requirement you examined and how you tested it. If you revised the prompt, show the failure and the exact edit. If you did not revise the prompt, explain why the recorded evidence did not justify an edit.
 - Run at least one test.
-- Regenerate the number of records in `hw1-session.jsonl`.
+- Count the completed, reviewed conversations in `hw1-session.jsonl`; exclude incomplete runs and drafts whose `met_requirement` is still `null`.
 
 The purpose of the recording is to connect your explanation to the committed artifacts. It is not a polished presentation.

--- a/homework/module-1/hw2.md
+++ b/homework/module-1/hw2.md
@@ -156,7 +156,7 @@ curl -s -X POST http://localhost:8010/sessions/SESSION_ID/messages \
   -d '{"message":"Show my recent orders."}'
 ```
 
-Submit at least five requests drawn from `hw1-session.jsonl`. For each request, use a session for the corresponding authenticated user and inspect the resulting trace in Langfuse.
+Submit at least five cases drawn from the completed, reviewed conversations in `hw1-session.jsonl`. For a multi-turn case, submit the requests from `turns` in order within the same session; the top-level `request` contains only the first turn. For each request, use a session for the corresponding authenticated user and inspect the resulting trace in Langfuse.
 
 In Langfuse, open the root span and tool spans and check the attributes listed in Parts A and C. Confirm that the response contains the session identifier, final reply, and prompt version. For an allowed tool call, confirm `cartwheel.permission_denied = false` with no denial reason. If a tool call returns a permission denial, confirm `cartwheel.permission_denied = true` and the recorded reason. You do not need to produce a permission denial or use a prescribed request.
 

--- a/product-manager-guidance-hw1.md
+++ b/product-manager-guidance-hw1.md
@@ -58,7 +58,7 @@ Walk me through Part B one conversation at a time. Cover all required cases and 
 
 Start each separate conversation in a fresh CLI session so earlier requests and tool results do not influence it. Quit and relaunch the CLI between conversations, keeping follow-up turns within the same conversation together. Resetting the order database does not clear conversation history.
 
-Handle the technical work of capturing the actual request, tool calls and results, and final response in hw1-session.jsonl. Inspect how the CLI exposes those details and arrange reliable capture if needed. Do not invent missing tool calls or results. Use my assessment for the judgment fields and help me distinguish a prompt failure, a tool failure, and an unclear requirement.
+Run the CLI with --save hw1-session.jsonl to capture the actual requests, tool calls and results, and responses. Quit after each conversation so its draft is saved. Review all saved turns with me, fill the judgment fields from my assessment, and exclude incomplete or unreviewed drafts from the required ten conversations. Do not invent missing tool calls or results. Use my assessment for the judgment fields and help me distinguish a prompt failure, a tool failure, and an unclear requirement.
 
 Explain when a refund or cancellation changes the local data. Reset between conversations when needed, preserving the records we have already saved and keeping state consistent within each conversation.
 

--- a/product-manager-guidance-hw1.md
+++ b/product-manager-guidance-hw1.md
@@ -58,7 +58,7 @@ Walk me through Part B one conversation at a time. Cover all required cases and 
 
 Start each separate conversation in a fresh CLI session so earlier requests and tool results do not influence it. Quit and relaunch the CLI between conversations, keeping follow-up turns within the same conversation together. Resetting the order database does not clear conversation history.
 
-Run the CLI with --save hw1-session.jsonl to capture the actual requests, tool calls and results, and responses. Quit after each conversation so its draft is saved. Review all saved turns with me, fill the judgment fields from my assessment, and exclude incomplete or unreviewed drafts from the required ten conversations. Do not invent missing tool calls or results. Use my assessment for the judgment fields and help me distinguish a prompt failure, a tool failure, and an unclear requirement.
+Run the CLI with --save hw1-session.jsonl to capture the actual requests, tool calls and results, and responses. Quit after each conversation so its draft is saved. Review all saved turns with me, fill the judgment fields from my assessment, and exclude incomplete or unreviewed drafts from the required ten conversations. Do not invent missing tool calls or results. Help me distinguish a prompt failure, a tool failure, and an unclear requirement.
 
 Explain when a refund or cancellation changes the local data. Reset between conversations when needed, preserving the records we have already saved and keeping state consistent within each conversation.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -211,3 +211,101 @@ def test_instrumentation_failure_does_not_report_success(monkeypatch) -> None:
     with pytest.raises(RuntimeError, match="failed to install"):
         instrument.instrument_genai(NoOpTracerProvider())
     assert instrument._genai_instrumented is False
+
+
+@pytest.fixture
+def recording_cli(tmp_path, monkeypatch, hosted_exports):
+    @function_tool
+    def lookup(order_id: int) -> dict:
+        return {"order_id": order_id, "eligible": order_id == 4127}
+
+    destination = tmp_path / "hw1-session.jsonl"
+    monkeypatch.setattr("sys.argv", ["agent.cli", "--save", str(destination)])
+    monkeypatch.setattr(cli, "load_env", lambda: None)
+    monkeypatch.setattr(cli, "resolve_auth", lambda *a: AuthContext(user_id=9002, role="merchant", store_id=2))
+    monkeypatch.setattr(cli, "SESSIONS_DB", tmp_path / "sessions.db")
+    monkeypatch.setattr(cli, "build_agent", lambda *a, **k: Agent(name="recording", model=ScriptedModel(), tools=[lookup]))
+    return destination
+
+
+@pytest.mark.parametrize("ending", ["quit", EOFError(), KeyboardInterrupt()])
+def test_save_groups_turns_appends_and_leaves_judgments_pending(recording_cli, monkeypatch, ending):
+    from unittest.mock import Mock
+
+    # A hand-edited existing JSONL file may lack its trailing newline.
+    recording_cli.write_text('{"existing": true}', encoding="utf-8")
+    ids = []
+    original_session = cli.SQLiteSession
+    monkeypatch.setattr(cli, "SQLiteSession", lambda sid, path: (ids.append(sid), original_session(sid, path))[1])
+    for _ in range(2):
+        monkeypatch.setattr("builtins.input", Mock(side_effect=['Check "both" café orders', "Follow up", ending]))
+        cli.main()
+    records = [json.loads(line) for line in recording_cli.read_text().splitlines()]
+    assert records[0] == {"existing": True}
+    assert len(records) == 3  # two conversations, not four turns
+    assert ids[0] != ids[1]
+    for record in records[1:]:
+        assert (record["role"], record["user_id"], record["store_id"]) == ("merchant", 9002, 2)
+        assert record["request"] == 'Check "both" café orders'
+        assert record["response"] == "Done."
+        assert len(record["turns"]) == 2
+        assert record["turns"][1]["tool_calls"] == []
+        assert [call["arguments"]["order_id"] for call in record["tool_calls"]] == [4127, 3980]
+        assert [call["result"]["eligible"] for call in record["tool_calls"]] == [True, False]
+        assert all(record[key] is None for key in ("expected", "requirement", "met_requirement", "problem_source"))
+        assert record["execution_complete"] is True
+        assert record["pending_request"] is None
+
+
+def test_empty_conversation_saves_no_record(recording_cli, monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _: "quit")
+    cli.main()
+    assert recording_cli.read_text() == ""
+
+
+def test_invalid_save_path_fails_before_input(recording_cli, monkeypatch):
+    monkeypatch.setattr("sys.argv", ["agent.cli", "--save", str(recording_cli / "missing.jsonl")])
+    monkeypatch.setattr("builtins.input", lambda _: pytest.fail("should fail before input"))
+    with pytest.raises(OSError):
+        cli.main()
+
+
+@pytest.mark.parametrize("after_completed_turn", [False, True])
+def test_failed_run_saves_incomplete_draft(recording_cli, monkeypatch, after_completed_turn):
+    from unittest.mock import Mock
+
+    original_run = cli.Runner.run
+    calls = 0
+
+    async def fail(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1 and after_completed_turn:
+            return await original_run(*args, **kwargs)
+        raise RuntimeError("model failed after possible tool activity")
+
+    monkeypatch.setattr(cli.Runner, "run", fail)
+    monkeypatch.setattr("builtins.input", Mock(side_effect=["Check both", "Pending request"]))
+    with pytest.raises(RuntimeError, match="model failed"):
+        cli.main()
+    record = json.loads(recording_cli.read_text())
+    assert record["execution_complete"] is False
+    assert len(record["turns"]) == int(after_completed_turn)
+    assert record["pending_request"] == ("Pending request" if after_completed_turn else "Check both")
+    assert record["met_requirement"] is None
+
+
+def test_approval_interruption_is_not_a_completed_conversation(recording_cli, monkeypatch):
+    from types import SimpleNamespace
+
+    async def pause(*args, **kwargs):
+        return SimpleNamespace(interruptions=[object()])
+
+    monkeypatch.setattr(cli.Runner, "run", pause)
+    monkeypatch.setattr("builtins.input", lambda _: "Refund")
+    with pytest.raises(NotImplementedError, match="m4"):
+        cli.main()
+    record = json.loads(recording_cli.read_text())
+    assert record["execution_complete"] is False
+    assert record["turns"] == []
+    assert record["pending_request"] == "Refund"


### PR DESCRIPTION
HW1 asks students to save actual conversation evidence, but the CLI only prints responses and stores SDK session history. Students or their coding agents currently have to build the submission JSONL themselves.

Add `--save hw1-session.jsonl` to append one factual draft per CLI conversation on exit. Save authenticated identity, the initial request, final response, tool calls/results, and ordered turns. Leave assessment fields null for the student to fill. Reuse the tool extraction for `--debug`; local recording needs no tracing service or new dependency.

Keep existing records, including a final line without a newline. Empty sessions add no record. Failed or interrupted runs are explicitly incomplete and identify the pending request, whose tool activity may be missing. Open the destination before model calls to catch invalid paths early. Use unique SDK session IDs so rapid restarts do not reuse conversation history.

Update the existing HW1 handout and PM guidance to explain draft completion and conversation counting. Clarify ordered replay of multi-turn cases in HW2. No new prompt, recording framework, or annotation UI.

Validation: 21 CLI tests passed, covering recording across turns and repeated sessions, debug/tracing behavior, null assessments, quit/EOF/Ctrl-C exits, empty sessions, invalid paths, failed model calls, and approval interruptions. Full offline suite: 100 passed, 12 skipped, 27 expected failures. Three independent subagent reviews converged with no actionable findings on the final implementation. Additional socket-blocked checks passed for real tool execution followed by model failure or cancellation, reordered tool results, no-tool conversations, debug plus recording, and serialization failures that preserve existing file contents. Live model calls were not used. Recording happens on exit and is not guaranteed after a forced process kill or write failure.
