### PR TITLE
fix: simplify database connection cleanup for homework

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -29,8 +29,8 @@ jobs:
         run: uv run pytest tests/eval -k "unit or integration" -q
       - name: Homework structural checks
         run: uv run pytest tests/test_hw_holes.py -q
-      - name: CLI debug output, with no model keys
-        run: uv run pytest tests/test_cli.py -q
+      - name: CLI and database lifecycle checks, with no model keys
+        run: uv run pytest tests/test_cli.py tests/test_db.py -q
 
   complete-evaluations:
     name: complete evaluations and leakage check

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -171,8 +171,7 @@ def search_help_center_logic(ctx: AuthContext, query: str, k: int = 3) -> dict[s
 
 def get_order_logic(ctx: AuthContext, order_id: int) -> dict[str, Any]:
     """Order lookup, gated by the access matrix."""
-    conn = db.connect()
-    try:
+    with db.connection() as conn:
         order = db.get_order(conn, order_id)
         if order is None:
             return {"ok": False, "error": "not_found", "reason": f"no order #{order_id}"}
@@ -184,8 +183,6 @@ def get_order_logic(ctx: AuthContext, order_id: int) -> dict[str, Any]:
         payload = order.to_public_dict()
         payload["store_name"] = store.name if store else None
         return {"ok": True, "order": payload}
-    finally:
-        conn.close()
 
 
 def issue_refund_logic(
@@ -213,8 +210,7 @@ def issue_refund_logic(
             "error": "invalid_argument",
             "reason": "refund amount must be positive",
         }
-    conn = db.connect()
-    try:
+    with db.connection() as conn:
         order = db.get_order(conn, order_id)
         if order is None:
             return {"ok": False, "error": "not_found", "reason": f"no order #{order_id}"}
@@ -281,8 +277,6 @@ def issue_refund_logic(
                 f"{facts['refund_processing_days_max']} business days"
             ),
         }
-    finally:
-        conn.close()
 
 
 def escalate_to_human_logic(
@@ -290,8 +284,7 @@ def escalate_to_human_logic(
 ) -> dict[str, Any]:
     """Open a ticket for a human support agent. Write tool."""
     facts = load_facts()
-    conn = db.connect()
-    try:
+    with db.connection() as conn:
         ticket_id = db.insert_escalation(
             conn,
             user_id=ctx.user_id,
@@ -306,8 +299,6 @@ def escalate_to_human_logic(
             "ticket_id": ticket_id,
             "sla_hours": facts["support_escalation_sla_hours"],
         }
-    finally:
-        conn.close()
 
 
 # ---------------------------------------------------------------------------

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -80,11 +80,8 @@ def _print_tool_calls(new_items: list[RunItem]) -> None:
 
 def resolve_auth(role: str, user_id: int | None) -> AuthContext:
     """Build the auth context from the users table (the injected block)."""
-    conn = db.connect()
-    try:
+    with db.connection() as conn:
         user = db.get_user(conn, user_id if user_id is not None else DEFAULT_USERS[role])
-    finally:
-        conn.close()
     if user is None:
         raise SystemExit(f"no such user id: {user_id}")
     if user.role != role:

--- a/agent/db.py
+++ b/agent/db.py
@@ -8,6 +8,7 @@ separable and testable. The schema itself is created by seed/generate.py.
 from __future__ import annotations
 
 import sqlite3
+from contextlib import closing
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
@@ -17,7 +18,7 @@ from agent.config import db_path
 
 
 def connect(path: Path | None = None) -> sqlite3.Connection:
-    """Open the world database. Caller closes it (or uses a context manager)."""
+    """Open the world database. Caller must close it; prefer connection()."""
     target = path or db_path()
     if not target.exists():
         raise FileNotFoundError(
@@ -26,6 +27,11 @@ def connect(path: Path | None = None) -> sqlite3.Connection:
     conn = sqlite3.connect(target)
     conn.row_factory = sqlite3.Row
     return conn
+
+
+def connection(path: Path | None = None) -> closing[sqlite3.Connection]:
+    """Open a connection that closes on block exit, without committing on exit."""
+    return closing(connect(path))
 
 
 def _parse_date(value: str | None) -> date | None:

--- a/agent/review.py
+++ b/agent/review.py
@@ -51,11 +51,8 @@ def resolve_support(user_id: int | None) -> AuthContext:
     support-only in code, and this refuses a non-support user id up front so
     the operator gets a clear message instead of a per-refund denial.
     """
-    conn = db.connect()
-    try:
+    with db.connection() as conn:
         user = db.get_user(conn, user_id if user_id is not None else DEFAULT_SUPPORT_USER)
-    finally:
-        conn.close()
     if user is None:
         raise SystemExit(f"no such user id: {user_id}")
     if user.role != "support":
@@ -90,8 +87,7 @@ def review_queue(operator: AuthContext) -> None:
     control; the code below it (``approve_refund`` / ``reject_refund``) is what
     actually authorizes and audits. Do not bypass those functions.
     """
-    conn = db.connect()
-    try:
+    with db.connection() as conn:
         ensure_approvals_table(conn)
         ### YOUR CODE HERE (m4)
         raise NotImplementedError(
@@ -99,8 +95,6 @@ def review_queue(operator: AuthContext) -> None:
             "record, prompt for a decision and reason, and call approve_refund / "
             "reject_refund)"
         )
-    finally:
-        conn.close()
 
 
 def main() -> None:

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -3,7 +3,7 @@
 The three lecture tools (`search_help_center`, `get_order`, `issue_refund`)
 are implemented in agent/agent.py and are worked examples of the pattern:
 check permissions first, go through agent/db.py for data, and return a
-structured dict, never a prose error. Your four tools follow the same
+structured dict, never a prose error. The homework tools follow the same
 pattern. agent/agent.py already wraps each function below as an SDK tool, so
 once a function works here it works in chat with no further wiring.
 
@@ -93,7 +93,7 @@ def search_products(
 
     Implementation notes:
         agent.db.list_products(conn, store_id) gives the candidate set.
-        Open the database with agent.db.connect() and close it when done.
+        Use `with db.connection() as conn:` to close the database automatically.
     """
     ### YOUR CODE HERE (HW1)
     raise NotImplementedError("HW1: implement search_products")

--- a/homework/module-1/hw1.md
+++ b/homework/module-1/hw1.md
@@ -58,6 +58,19 @@ The supplied data access layer in `agent/db.py` provides the database operations
 - `get_policy` reads the generated policy files with `load_policy_docs` from `agent/helpcenter.py`.
 - `find_order` searches the authenticated user's orders by product name. Use `list_orders_for_user` and filter by matching the query against product names.
 
+Use `with db.connection() as conn:` for database access. It closes the connection
+automatically, including on early returns and errors:
+
+```python
+with db.connection() as conn:
+    order = db.get_order(conn, order_id)
+```
+
+The supplied write helpers commit their changes. The `with` block only handles
+closing; it does not commit pending writes. Existing code that uses `db.connect()`
+and closes it explicitly still works. A bare `with db.connect()` does not close
+a SQLite connection.
+
 Use the supplied functions rather than writing a second database layer. Each tool docstring states the required inputs, return value, and error behavior.
 
 `SPEC.md` is a design document; the running application does not load it. The starter translates the specification into three kinds of implementation:

--- a/homework/module-1/hw1.md
+++ b/homework/module-1/hw1.md
@@ -1,6 +1,6 @@
 # Homework 1, implementing and examining the support agent
 
-Homework 1 asks you to complete four tools for the Cartwheel support agent and examine the resulting behavior through manual conversations.
+Homework 1 asks you to complete five tools for the Cartwheel support agent and examine the resulting behavior through manual conversations.
 
 ## Expected work
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,108 @@
+"""Connection cleanup and unchanged SQLite write behavior; no model calls."""
+
+from pathlib import Path
+import sqlite3
+
+import pytest
+
+from agent import db, review
+from agent.agent import escalate_to_human_logic, get_order_logic, issue_refund_logic
+from agent.auth import AuthContext
+from agent.cli import resolve_auth
+from agent.review import resolve_support, review_queue
+
+
+@pytest.mark.parametrize("exit_kind", ["normal", "return", "error"])
+def test_connection_closes_on_every_exit(world_copy: Path, exit_kind: str) -> None:
+    opened = []
+    error = RuntimeError("original error")
+
+    def run() -> None:
+        with db.connection() as conn:
+            opened.append(conn)
+            assert conn.execute("SELECT 1 AS value").fetchone()["value"] == 1
+            if exit_kind == "return":
+                return
+            if exit_kind == "error":
+                raise error
+
+    if exit_kind == "error":
+        with pytest.raises(RuntimeError) as caught:
+            run()
+        assert caught.value is error
+    else:
+        run()
+    with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+        opened[0].execute("SELECT 1")
+
+
+@pytest.mark.parametrize("raise_error", [False, True])
+def test_uncommitted_writes_are_not_committed_on_exit(world_copy: Path, raise_error: bool) -> None:
+    with db.connection() as conn:
+        before = db.get_order(conn, 4127).status
+    try:
+        with db.connection() as conn:
+            conn.execute("UPDATE orders SET status = 'cancelled' WHERE id = 4127")
+            if raise_error:
+                raise RuntimeError("abort")
+    except RuntimeError:
+        pass
+    with db.connection() as conn:
+        assert db.get_order(conn, 4127).status == before
+
+
+def test_existing_helper_commits_survive_later_error(world_copy: Path) -> None:
+    with pytest.raises(RuntimeError, match="later failure"):
+        with db.connection() as conn:
+            db.set_order_status(conn, 4127, "cancelled")
+            raise RuntimeError("later failure")
+    with db.connection() as conn:
+        assert db.get_order(conn, 4127).status == "cancelled"
+
+
+def test_explicit_path_overrides_environment(world_copy: Path, monkeypatch, tmp_path: Path) -> None:
+    missing = tmp_path / "missing.db"
+    monkeypatch.setenv("CARTWHEEL_DB", str(missing))
+    with db.connection(world_copy) as conn:
+        assert db.get_order(conn, 4127).id == 4127
+    with pytest.raises(FileNotFoundError, match="seed.generate"):
+        with db.connection():
+            pytest.fail("missing database must fail before entering the block")
+    assert not missing.exists()
+
+
+@pytest.mark.parametrize("operation", ["lookup", "denied", "refund", "escalate", "cli", "support", "review"])
+def test_supplied_callers_close_connections(world_copy: Path, monkeypatch, operation: str) -> None:
+    opened = []
+    original_connect = db.connect
+
+    def tracked_connect(path=None):
+        conn = original_connect(path)
+        opened.append(conn)
+        return conn
+
+    monkeypatch.setattr(db, "connect", tracked_connect)
+    shopper = AuthContext(user_id=1, role="shopper")
+    if operation == "lookup":
+        assert get_order_logic(shopper, 4127)["ok"]
+    elif operation == "denied":
+        result = get_order_logic(AuthContext(user_id=9002, role="merchant", store_id=2), 4127)
+        assert result["error"] == "permission_denied"
+    elif operation == "refund":
+        assert issue_refund_logic(shopper, 4127, 84, "test")["status"] == "auto_approved"
+    elif operation == "escalate":
+        assert escalate_to_human_logic(shopper, "account help", "student needs assistance")["ok"]
+    elif operation == "cli":
+        assert resolve_auth("shopper", 1).user_id == 1
+    elif operation == "support":
+        assert resolve_support(9501).role == "support"
+    else:
+        # Fail in supplied setup, without requiring the HW8 student seam to stay unfinished.
+        def setup_failure(conn):
+            raise RuntimeError("review setup failed")
+        monkeypatch.setattr(review, "ensure_approvals_table", setup_failure)
+        with pytest.raises(RuntimeError, match="review setup failed"):
+            review_queue(AuthContext(user_id=9501, role="support"))
+    assert len(opened) == 1
+    with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+        opened[0].execute("SELECT 1")


### PR DESCRIPTION
HW1 students currently have to repeat `db.connect()` plus `try/finally` cleanup in database-backed tools. Add `db.connection()`, a small wrapper around the standard library's `contextlib.closing`, and use `with db.connection() as conn:` in the six supplied call sites.

Connections close on normal exit, early return, and exceptions. Existing database helper signatures and commit behavior are unchanged, so completed student tools and later approval exercises still work. The wrapper does not commit on exit. Correct the misleading raw-connection docstring and update the existing HW1 instructions and product-search implementation note. No new prompts, dependencies, or database abstraction layer.

Production code is reduced by 12 lines. The implementation lives in `agent/db.py`; callers share it.

Validation:
- Full suite: 106 passed, 12 skipped, 27 expected failures.
- 14 new offline tests cover closure, original exception propagation, committed/uncommitted write behavior, explicit paths and environment selection, missing databases, and all six supplied connection scopes. The review-loop test injects a setup failure so it does not require the student exercise to remain unfinished.
- Existing permission, refund, CLI and approval tests remain intact. CI runs the new database tests alongside the CLI checks, without model API keys.

The unrelated complete-evaluations job currently fails at the HW6 `find_leaks` placeholder; its investigation is separate.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-evals-course/cartwheel-homeworks/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->