### PR TITLE
refactor: share SDK tool result extraction and test helpers

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Homework structural checks
         run: uv run pytest tests/test_hw_holes.py -q
       - name: CLI and database lifecycle checks, with no model keys
-        run: uv run pytest tests/test_cli.py tests/test_db.py -q
+        run: uv run pytest tests/test_cli.py tests/test_run_items.py tests/test_db.py -q
 
   complete-evaluations:
     name: complete evaluations and leakage check

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -29,7 +29,7 @@ jobs:
         run: uv run pytest tests/eval -k "unit or integration" -q
       - name: Homework structural checks
         run: uv run pytest tests/test_hw_holes.py -q
-      - name: CLI and database lifecycle checks, with no model keys
+      - name: CLI, replay, and database checks, with no model keys
         run: uv run pytest tests/test_cli.py tests/test_run_items.py tests/test_db.py -q
 
   complete-evaluations:

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -310,10 +310,10 @@ def escalate_to_human_logic(
 
 
 def _call(
-    wrapper: RunContextWrapper[AuthContext], fn: Any, /, *args: Any
+    wrapper: RunContextWrapper[AuthContext], fn: Any, /, *args: Any, **kwargs: Any
 ) -> dict[str, Any]:
     try:
-        result = fn(wrapper.context, *args)
+        result = fn(wrapper.context, *args, **kwargs)
     except NotImplementedError as exc:
         result = {"ok": False, "error": "not_implemented", "reason": str(exc)}
     record_tool_result(wrapper.context, result)
@@ -374,15 +374,10 @@ def search_products(
     limit: int = 5,
 ) -> dict[str, Any]:
     """Search the product catalog, optionally within one store or under a price."""
-    ctx = wrapper.context
-    try:
-        result = hw_tools.search_products(
-            ctx, query, store=store, max_price_usd=max_price_usd, limit=limit
-        )
-    except NotImplementedError as exc:
-        result = {"ok": False, "error": "not_implemented", "reason": str(exc)}
-    record_tool_result(ctx, result)
-    return result
+    return _call(
+        wrapper, hw_tools.search_products, query,
+        store=store, max_price_usd=max_price_usd, limit=limit,
+    )
 
 
 @function_tool

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import json
 import time
 
 from agents import RunConfig, Runner, SQLiteSession
@@ -40,6 +39,7 @@ from agent import db
 from agent.agent import build_agent, prompt_version, render_system_prompt
 from agent.auth import AuthContext
 from agent.config import REPO_ROOT
+from agent.run_items import tool_calls_from_items
 from observability.instrument import load_env, setup_tracing
 
 DEFAULT_USERS = {"shopper": 1, "merchant": 9001, "support": 9501}
@@ -55,27 +55,10 @@ def _print_tool_calls(new_items: list[RunItem]) -> None:
     `result.new_items`, independent of whether tracing is configured, so
     this is accurate with or without --trace.
     """
-    outputs = {
-        item.call_id: item.output
-        for item in new_items
-        if item.type == "tool_call_output_item" and item.call_id is not None
-    }
-    for item in new_items:
-        if item.type == "tool_call_item":
-            raw = item.raw_item
-            args = (
-                raw.get("arguments")
-                if isinstance(raw, dict)
-                else getattr(raw, "arguments", None)
-            )
-            if isinstance(args, str):
-                try:
-                    args = json.loads(args)
-                except json.JSONDecodeError:
-                    pass
-            print(f"  [tool] {item.tool_name}({args})")
-            if item.call_id in outputs:
-                print(f"    -> {outputs[item.call_id]}")
+    for call in tool_calls_from_items(new_items):
+        print(f"  [tool] {call['name']}({call['args']})")
+        if "result" in call:
+            print(f"    -> {call['result']}")
 
 
 def resolve_auth(role: str, user_id: int | None) -> AuthContext:

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import time
 
 from agents import RunConfig, Runner, SQLiteSession
@@ -56,7 +57,13 @@ def _print_tool_calls(new_items: list[RunItem]) -> None:
     this is accurate with or without --trace.
     """
     for call in tool_calls_from_items(new_items):
-        print(f"  [tool] {call['name']}({call['args']})")
+        args = call["arguments"]
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except json.JSONDecodeError:
+                pass
+        print(f"  [tool] {call['name']}({args})")
         if "result" in call:
             print(f"    -> {call['result']}")
 

--- a/agent/run_items.py
+++ b/agent/run_items.py
@@ -1,0 +1,43 @@
+"""Shared extraction of tool calls from Agents SDK run items."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, NotRequired, TypedDict
+
+from agents.items import RunItem
+
+
+class ToolCallRecord(TypedDict):
+    name: str | None
+    args: Any
+    result: NotRequired[Any]
+
+
+def tool_calls_from_items(items: list[RunItem]) -> list[ToolCallRecord]:
+    """Return calls in order, matching results by call ID.
+
+    A missing result key means no output arrived; an output can itself be
+    None. Keep malformed argument strings available for inspection.
+    """
+    outputs = {
+        item.call_id: item.output
+        for item in items
+        if item.type == "tool_call_output_item" and item.call_id is not None
+    }
+    calls: list[ToolCallRecord] = []
+    for item in items:
+        if item.type != "tool_call_item":
+            continue
+        raw = item.raw_item
+        args = raw.get("arguments") if isinstance(raw, dict) else getattr(raw, "arguments", None)
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except json.JSONDecodeError:
+                pass
+        call: ToolCallRecord = {"name": item.tool_name, "args": args}
+        if item.call_id in outputs:
+            call["result"] = outputs[item.call_id]
+        calls.append(call)
+    return calls

--- a/agent/run_items.py
+++ b/agent/run_items.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from typing import Any, NotRequired, TypedDict
 
 from agents.items import RunItem
@@ -10,15 +9,15 @@ from agents.items import RunItem
 
 class ToolCallRecord(TypedDict):
     name: str | None
-    args: Any
+    arguments: Any
     result: NotRequired[Any]
 
 
 def tool_calls_from_items(items: list[RunItem]) -> list[ToolCallRecord]:
-    """Return calls in order, matching results by call ID.
+    """Return calls with raw SDK arguments, matching results by call ID.
 
     A missing result key means no output arrived; an output can itself be
-    None. Keep malformed argument strings available for inspection.
+    None. Each consumer decides how to decode the arguments.
     """
     outputs = {
         item.call_id: item.output
@@ -30,13 +29,10 @@ def tool_calls_from_items(items: list[RunItem]) -> list[ToolCallRecord]:
         if item.type != "tool_call_item":
             continue
         raw = item.raw_item
-        args = raw.get("arguments") if isinstance(raw, dict) else getattr(raw, "arguments", None)
-        if isinstance(args, str):
-            try:
-                args = json.loads(args)
-            except json.JSONDecodeError:
-                pass
-        call: ToolCallRecord = {"name": item.tool_name, "args": args}
+        arguments = (
+            raw.get("arguments") if isinstance(raw, dict) else getattr(raw, "arguments", None)
+        )
+        call: ToolCallRecord = {"name": item.tool_name, "arguments": arguments}
         if item.call_id in outputs:
             call["result"] = outputs[item.call_id]
         calls.append(call)

--- a/replay/rollout.py
+++ b/replay/rollout.py
@@ -132,38 +132,23 @@ def _auth_context(case_input: dict[str, Any]) -> Any:
 
 def _extract_turn(new_items: list[Any]) -> dict[str, Any]:
     """Collapse one Runner turn's items into {reply, tool_calls, steps}."""
-    from agents.items import MessageOutputItem, ToolCallItem, ToolCallOutputItem
+    from agents.items import MessageOutputItem
 
-    calls: dict[str, dict[str, Any]] = {}
-    ordered: list[dict[str, Any]] = []
+    from agent.run_items import tool_calls_from_items
+
     reply_parts: list[str] = []
     for item in new_items:
-        if isinstance(item, ToolCallItem):
-            raw = item.raw_item
-            record = {
-                "name": getattr(raw, "name", None),
-                "args": json.loads(getattr(raw, "arguments", None) or "{}"),
-                "result": None,
-            }
-            calls[getattr(raw, "call_id", None)] = record
-            ordered.append(record)
-        elif isinstance(item, ToolCallOutputItem):
-            call_id = None
-            raw = item.raw_item
-            if isinstance(raw, dict):
-                call_id = raw.get("call_id")
-            else:
-                call_id = getattr(raw, "call_id", None)
-            if call_id in calls:
-                calls[call_id]["result"] = item.output
-        elif isinstance(item, MessageOutputItem):
+        if isinstance(item, MessageOutputItem):
             for part in getattr(item.raw_item, "content", []) or []:
                 text = getattr(part, "text", None)
                 if text:
                     reply_parts.append(text)
     return {
         "reply": "\n".join(reply_parts),
-        "tool_calls": ordered,
+        "tool_calls": [
+            {**call, "result": call.get("result")}
+            for call in tool_calls_from_items(new_items)
+        ],
         "steps": len(new_items),
     }
 

--- a/replay/rollout.py
+++ b/replay/rollout.py
@@ -146,7 +146,11 @@ def _extract_turn(new_items: list[Any]) -> dict[str, Any]:
     return {
         "reply": "\n".join(reply_parts),
         "tool_calls": [
-            {**call, "result": call.get("result")}
+            {
+                "name": call["name"],
+                "args": json.loads(call["arguments"] or "{}"),
+                "result": call.get("result"),
+            }
             for call in tool_calls_from_items(new_items)
         ],
         "steps": len(new_items),

--- a/tests/eval/test_integration.py
+++ b/tests/eval/test_integration.py
@@ -8,6 +8,10 @@ the REAL tool plumbing. They run on every push, with zero API calls.
 
 What each test isolates:
 
+  - Wrapper delegation: search_products forwards arguments, records its
+    result, and converts NotImplementedError into a structured tool error.
+    This checks the SDK tool boundary without a model call.
+
   - Grounding: fix the retrieved-docs set (mock the retrieval tool) and
     assert the model's next-turn context contains exactly those docs. With
     a live model, the follow-on assertion is that the answer cites the store

--- a/tests/eval/test_integration.py
+++ b/tests/eval/test_integration.py
@@ -27,18 +27,46 @@ What each test isolates:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import sqlite3
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from agents import Agent, Runner
+from agents.tool_context import ToolContext
 
-from agent.agent import TOOLS_BY_ROLE, render_system_prompt
+from agent.agent import TOOLS_BY_ROLE, render_system_prompt, search_products
 from agent.auth import AuthContext
 from tests.eval.fake_model import FakeModel, text_message, tool_call
 
 SHOPPER_1 = AuthContext(user_id=1, role="shopper")
+
+
+@pytest.mark.parametrize("implemented", [False, True])
+def test_integration_search_products_wrapper(implemented: bool) -> None:
+    arguments = json.dumps({"query": "mug", "store": "Ceramics", "max_price_usd": 25, "limit": 2})
+    context = ToolContext(
+        context=SHOPPER_1, tool_name="search_products",
+        tool_call_id="search", tool_arguments=arguments,
+    )
+    expected = (
+        {"ok": True, "products": []} if implemented else
+        {"ok": False, "error": "not_implemented", "reason": "homework hole"}
+    )
+    with (
+        patch(
+            "agent.agent.hw_tools.search_products", return_value=expected,
+            side_effect=None if implemented else NotImplementedError("homework hole"),
+        ) as search,
+        patch("agent.agent.record_tool_result") as record,
+    ):
+        result = asyncio.run(search_products.on_invoke_tool(context, arguments))
+
+    assert result == expected
+    search.assert_called_once_with(SHOPPER_1, "mug", store="Ceramics", max_price_usd=25, limit=2)
+    record.assert_called_once_with(SHOPPER_1, expected)
 
 
 def _build_fake_agent(ctx: AuthContext, fake: FakeModel) -> Agent[AuthContext]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,24 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-import json
-from typing import Any
 
 import httpx
 import langfuse
 import pytest
 from agents import Agent, function_tool
-from agents.items import ModelResponse
-from agents.models.interface import Model
 from agents.tracing import get_trace_provider, set_trace_provider, trace
 from agents.tracing.processors import BackendSpanExporter, BatchTraceProcessor
 from agents.tracing.provider import DefaultTraceProvider
-from agents.usage import Usage
-from openai.types.responses import (
-    ResponseFunctionToolCall,
-    ResponseOutputMessage,
-    ResponseOutputText,
-)
 from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
 from opentelemetry.trace import NoOpTracerProvider
 from opentelemetry.sdk.trace import TracerProvider
@@ -30,41 +20,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from agent import cli
 from agent.auth import AuthContext
 from observability import instrument
-
-
-class ScriptedModel(Model):
-    def __init__(self) -> None:
-        self.calls = 0
-
-    async def get_response(self, *args: Any, **kwargs: Any) -> ModelResponse:
-        self.calls += 1
-        if self.calls == 1:
-            output = [
-                ResponseFunctionToolCall(
-                    type="function_call",
-                    call_id=f"call-{order_id}",
-                    name="lookup",
-                    arguments=json.dumps({"order_id": order_id}),
-                )
-                for order_id in (4127, 3980)
-            ]
-        else:
-            output = [
-                ResponseOutputMessage(
-                    id="reply",
-                    type="message",
-                    role="assistant",
-                    status="completed",
-                    content=[
-                        ResponseOutputText(type="output_text", text="Done.", annotations=[])
-                    ],
-                )
-            ]
-        return ModelResponse(output=output, usage=Usage(), response_id=None)
-
-    async def stream_response(self, *args: Any, **kwargs: Any):
-        raise NotImplementedError("The CLI uses non-streaming runs")
-        yield
+from tests.eval.fake_model import FakeModel, text_message, tool_call
 
 
 @pytest.fixture
@@ -109,7 +65,9 @@ def test_cli_tool_results(debug, tracing, tmp_path, monkeypatch, capsys, caplog,
         executed.append(order_id)
         return {"eligible": order_id == 4127}
 
-    model = ScriptedModel()
+    model = FakeModel()
+    model.set_next_output([tool_call("lookup", {"order_id": oid}) for oid in (4127, 3980)])
+    model.set_next_output([text_message("Done.")])
     agent = Agent(name="offline-cli", model=model, tools=[lookup])
     ctx = AuthContext(user_id=1, role="shopper")
     messages = iter(["Check both orders", "quit"])
@@ -144,7 +102,7 @@ def test_cli_tool_results(debug, tracing, tmp_path, monkeypatch, capsys, caplog,
     try:
         cli.main()
         assert sorted(executed) == [3980, 4127]
-        assert model.calls == 2
+        assert len(model.requests) == 2
         output = capsys.readouterr().out
         if debug:
             assert (

--- a/tests/test_run_items.py
+++ b/tests/test_run_items.py
@@ -1,5 +1,8 @@
 """Keep CLI debug output and replay transcripts consistent with SDK items."""
 
+import json
+
+import pytest
 from agents import Agent
 from agents.items import MessageOutputItem, ToolCallItem, ToolCallOutputItem
 
@@ -39,10 +42,9 @@ def test_cli_and_replay_pair_repeated_calls_by_id(capsys) -> None:
     }
 
 
-def test_missing_output_differs_from_none_and_keeps_malformed_arguments(capsys) -> None:
+def test_missing_output_differs_from_none(capsys) -> None:
     agent = Agent(name="offline")
     missing = tool_call("lookup", {})
-    missing.arguments = "{unfinished"
     completed = tool_call("lookup", {})
     items = [
         ToolCallItem(agent=agent, raw_item=missing),
@@ -52,15 +54,41 @@ def test_missing_output_differs_from_none_and_keeps_malformed_arguments(capsys) 
 
     _print_tool_calls(items)
     assert capsys.readouterr().out == (
-        "  [tool] lookup({unfinished)\n"
+        "  [tool] lookup({})\n"
         "  [tool] lookup({})\n    -> None\n"
     )
     # Replay keeps its existing schema, with a result key even when output is absent.
     assert _extract_turn(items) == {
         "reply": "",
         "tool_calls": [
-            {"name": "lookup", "args": "{unfinished", "result": None},
+            {"name": "lookup", "args": {}, "result": None},
             {"name": "lookup", "args": {}, "result": None},
         ],
         "steps": 3,
     }
+
+
+@pytest.mark.parametrize(
+    "arguments,cli_args,replay_args", [("", "", {}), ("null", "None", None)]
+)
+def test_empty_arguments_and_json_null_keep_consumer_formats(
+    arguments, cli_args, replay_args, capsys
+) -> None:
+    raw = tool_call("lookup", {})
+    raw.arguments = arguments
+    items = [ToolCallItem(agent=Agent(name="offline"), raw_item=raw)]
+
+    _print_tool_calls(items)
+    assert capsys.readouterr().out == f"  [tool] lookup({cli_args})\n"
+    assert _extract_turn(items)["tool_calls"][0]["args"] == replay_args
+
+
+def test_malformed_arguments_print_in_cli_and_raise_in_replay(capsys) -> None:
+    raw = tool_call("lookup", {})
+    raw.arguments = "{unfinished"
+    items = [ToolCallItem(agent=Agent(name="offline"), raw_item=raw)]
+
+    _print_tool_calls(items)
+    assert capsys.readouterr().out == "  [tool] lookup({unfinished)\n"
+    with pytest.raises(json.JSONDecodeError):
+        _extract_turn(items)

--- a/tests/test_run_items.py
+++ b/tests/test_run_items.py
@@ -1,0 +1,66 @@
+"""Keep CLI debug output and replay transcripts consistent with SDK items."""
+
+from agents import Agent
+from agents.items import MessageOutputItem, ToolCallItem, ToolCallOutputItem
+
+from agent.cli import _print_tool_calls
+from replay.rollout import _extract_turn
+from tests.eval.fake_model import text_message, tool_call
+
+
+def test_cli_and_replay_pair_repeated_calls_by_id(capsys) -> None:
+    agent = Agent(name="offline")
+    first = tool_call("lookup", {"order_id": 4127})
+    second = tool_call("lookup", {"order_id": 3980})
+    items = [
+        ToolCallItem(agent=agent, raw_item=first),
+        ToolCallItem(agent=agent, raw_item=second.model_dump()),
+        ToolCallOutputItem(
+            agent=agent, raw_item={"call_id": second.call_id}, output={"eligible": False}
+        ),
+        ToolCallOutputItem(
+            agent=agent, raw_item={"call_id": first.call_id}, output={"eligible": True}
+        ),
+        MessageOutputItem(agent=agent, raw_item=text_message("Done.")),
+    ]
+
+    _print_tool_calls(items)
+    assert capsys.readouterr().out == (
+        "  [tool] lookup({'order_id': 4127})\n    -> {'eligible': True}\n"
+        "  [tool] lookup({'order_id': 3980})\n    -> {'eligible': False}\n"
+    )
+    assert _extract_turn(items) == {
+        "reply": "Done.",
+        "tool_calls": [
+            {"name": "lookup", "args": {"order_id": 4127}, "result": {"eligible": True}},
+            {"name": "lookup", "args": {"order_id": 3980}, "result": {"eligible": False}},
+        ],
+        "steps": 5,
+    }
+
+
+def test_missing_output_differs_from_none_and_keeps_malformed_arguments(capsys) -> None:
+    agent = Agent(name="offline")
+    missing = tool_call("lookup", {})
+    missing.arguments = "{unfinished"
+    completed = tool_call("lookup", {})
+    items = [
+        ToolCallItem(agent=agent, raw_item=missing),
+        ToolCallItem(agent=agent, raw_item=completed),
+        ToolCallOutputItem(agent=agent, raw_item={"call_id": completed.call_id}, output=None),
+    ]
+
+    _print_tool_calls(items)
+    assert capsys.readouterr().out == (
+        "  [tool] lookup({unfinished)\n"
+        "  [tool] lookup({})\n    -> None\n"
+    )
+    # Replay keeps its existing schema, with a result key even when output is absent.
+    assert _extract_turn(items) == {
+        "reply": "",
+        "tool_calls": [
+            {"name": "lookup", "args": "{unfinished", "result": None},
+            {"name": "lookup", "args": {}, "result": None},
+        ],
+        "steps": 3,
+    }


### PR DESCRIPTION
CLI debug output and replay each extracted SDK tool calls and matched their results. They now share `agent/run_items.py` for raw extraction and pairing by call ID. Each consumer keeps its existing JSON decoding: CLI tolerates malformed strings for display, while replay converts empty arguments to `{}` and raises on malformed JSON.

The CLI tests reuse the existing `FakeModel`. The `search_products` wrapper delegates to `_call`, which now forwards keyword arguments. Tool signatures and homework holes remain unchanged. This builds on the current tracing and database connection fixes.

The shared helper exposes raw `arguments` and an optional `result`. The CLI can distinguish a missing output from an explicit `None` result. Replay keeps its existing decoded `args` and always-present `result` fields.

Validation and review:

- Full offline suite: 113 passed, 12 skipped, 27 expected failures. GitHub offline checks passed on the final PR commit (`2d09753`).
- Regression tests cover repeated tool names, output ordering, SDK object and dictionary calls, missing outputs, empty arguments, JSON null, malformed arguments, and wrapper keyword forwarding. The new test file is included in the existing offline CI command.
- Three independent subagent reviews approved the final correction. During iteration, a real SDK probe exposed an empty-argument representation change; keeping decoding in each consumer preserves the prior behavior without helper flags or callbacks.
- Direct Fable 5.1 review returned **SHIP, no blockers**, with workflows and ultracode disabled. It ran all 23 focused tests. Applied its optional test-docstring and CI-label suggestions.
- The PR full-evaluation job stops at the existing `NotImplementedError("hw6: implement find_leaks")` in `scripts/check_leakage.py`. That homework hole is unchanged.

The change removes duplicate implementations. New types and regression tests increase the total line count.

Squash merge recommended so the intermediate argument-parsing change stays out of main history.
