### PR TITLE
test: reuse existing fake model in CLI tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,24 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-import json
-from typing import Any
 
 import httpx
 import langfuse
 import pytest
 from agents import Agent, function_tool
-from agents.items import ModelResponse
-from agents.models.interface import Model
 from agents.tracing import get_trace_provider, set_trace_provider, trace
 from agents.tracing.processors import BackendSpanExporter, BatchTraceProcessor
 from agents.tracing.provider import DefaultTraceProvider
-from agents.usage import Usage
-from openai.types.responses import (
-    ResponseFunctionToolCall,
-    ResponseOutputMessage,
-    ResponseOutputText,
-)
 from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
 from opentelemetry.trace import NoOpTracerProvider
 from opentelemetry.sdk.trace import TracerProvider
@@ -30,41 +20,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from agent import cli
 from agent.auth import AuthContext
 from observability import instrument
-
-
-class ScriptedModel(Model):
-    def __init__(self) -> None:
-        self.calls = 0
-
-    async def get_response(self, *args: Any, **kwargs: Any) -> ModelResponse:
-        self.calls += 1
-        if self.calls == 1:
-            output = [
-                ResponseFunctionToolCall(
-                    type="function_call",
-                    call_id=f"call-{order_id}",
-                    name="lookup",
-                    arguments=json.dumps({"order_id": order_id}),
-                )
-                for order_id in (4127, 3980)
-            ]
-        else:
-            output = [
-                ResponseOutputMessage(
-                    id="reply",
-                    type="message",
-                    role="assistant",
-                    status="completed",
-                    content=[
-                        ResponseOutputText(type="output_text", text="Done.", annotations=[])
-                    ],
-                )
-            ]
-        return ModelResponse(output=output, usage=Usage(), response_id=None)
-
-    async def stream_response(self, *args: Any, **kwargs: Any):
-        raise NotImplementedError("The CLI uses non-streaming runs")
-        yield
+from tests.eval.fake_model import FakeModel, text_message, tool_call
 
 
 @pytest.fixture
@@ -109,7 +65,12 @@ def test_cli_tool_results(debug, tracing, tmp_path, monkeypatch, capsys, caplog,
         executed.append(order_id)
         return {"eligible": order_id == 4127}
 
-    model = ScriptedModel()
+    model = FakeModel()
+    model.set_next_output([
+        tool_call("lookup", {"order_id": 4127}),
+        tool_call("lookup", {"order_id": 3980}),
+    ])
+    model.set_next_output([text_message("Done.")])
     agent = Agent(name="offline-cli", model=model, tools=[lookup])
     ctx = AuthContext(user_id=1, role="shopper")
     messages = iter(["Check both orders", "quit"])
@@ -144,7 +105,7 @@ def test_cli_tool_results(debug, tracing, tmp_path, monkeypatch, capsys, caplog,
     try:
         cli.main()
         assert sorted(executed) == [3980, 4127]
-        assert model.calls == 2
+        assert len(model.requests) == 2
         output = capsys.readouterr().out
         if debug:
             assert (


### PR DESCRIPTION
Reuse the existing helper that simulates AI replies, removing duplicate code from the CLI test. The test still checks the same behavior.