### PR TITLE
fix: correct review save paths and simultaneous saves

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -29,8 +29,8 @@ jobs:
         run: uv run pytest tests/eval -k "unit or integration" -q
       - name: Homework structural checks
         run: uv run pytest tests/test_hw_holes.py -q
-      - name: CLI and database lifecycle checks, with no model keys
-        run: uv run pytest tests/test_cli.py tests/test_db.py -q
+      - name: CLI, database, and review-server checks, with no model keys
+        run: uv run pytest tests/test_cli.py tests/test_db.py tests/test_review_server.py -q
 
   complete-evaluations:
     name: complete evaluations and leakage check

--- a/analysis/server.py
+++ b/analysis/server.py
@@ -42,6 +42,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import tempfile
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -49,7 +51,8 @@ from pathlib import Path
 from typing import Any
 
 HERE = Path(__file__).resolve().parent
-STATE_DIR = HERE / "state"
+# Resolve once at startup; API saves and replay use the same state directory.
+STATE_DIR = Path(os.environ.get("CARTWHEEL_ANALYSIS_STATE") or HERE / "state")
 UI_DIR = HERE / "ui"
 
 # API path -> the state file that backs it. GET reads the file, POST overwrites
@@ -92,9 +95,15 @@ def _read_json(path: Path, default: Any) -> Any:
 def _write_json(path: Path, data: Any) -> None:
     """Write ``data`` to ``path`` atomically (write temp, then replace)."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(json.dumps(data, indent=2))
-    tmp.replace(path)
+    # Each request needs its own temp file: the HTTP server handles saves in threads.
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as handle:
+            handle.write(json.dumps(data, indent=2))
+        os.replace(tmp, path)
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise
 
 
 class ReviewHandler(BaseHTTPRequestHandler):

--- a/tests/test_review_server.py
+++ b/tests/test_review_server.py
@@ -1,0 +1,83 @@
+"""Regression checks for the review server's state directory and atomic saves."""
+
+import importlib.util
+import json
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def server(tmp_path, monkeypatch):
+    monkeypatch.setenv("CARTWHEEL_ANALYSIS_STATE", str(tmp_path / "state"))
+    # Load afresh because the server resolves its state directory at startup.
+    source = Path(__file__).resolve().parents[1] / "analysis/server.py"
+    spec = importlib.util.spec_from_file_location("review_server", source)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_state_override_includes_api_files_and_replay(server, tmp_path):
+    state = tmp_path / "state"
+    assert server.STATE_DIR == state
+    assert all(path.parent == state for path in server.API_FILES.values())
+    for path in server.API_FILES.values():
+        server._write_json(path, [])
+        assert json.loads(path.read_text()) == []
+
+    canned = tmp_path / "canned.json"
+    annotations = [{"id": "demo", "note": "late delivery"}]
+    canned.write_text(json.dumps({"annotations": annotations}))
+    server._replay_annotations(canned, interval=0)
+    assert json.loads((state / "annotations.json").read_text()) == annotations
+
+
+def test_concurrent_saves_use_distinct_complete_files(server, tmp_path, monkeypatch):
+    path = tmp_path / "state/annotations.json"
+    payloads = [{"writer": i, "note": "x" * 10000} for i in range(2)]
+    ready = threading.Barrier(2)
+    replace = os.replace
+    temp_paths = []
+
+    def synchronized_replace(src, dst):
+        temp_paths.append(Path(src))
+        # Both saves finish writing before either replaces the destination.
+        ready.wait(timeout=5)
+        assert json.loads(Path(src).read_text()) in payloads
+        return replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", synchronized_replace)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(server._write_json, path, payload) for payload in payloads]
+        for future in futures:
+            future.result(timeout=10)
+    assert len(set(temp_paths)) == 2
+    assert json.loads(path.read_text()) in payloads
+    assert list(path.parent.iterdir()) == [path]
+
+
+def test_failed_serialization_preserves_previous_file(server, tmp_path):
+    path = tmp_path / "annotations.json"
+    path.write_text("[]")
+    with pytest.raises(TypeError):
+        server._write_json(path, {"bad": object()})
+    assert path.read_text() == "[]"
+    assert list(tmp_path.iterdir()) == [path]
+
+
+def test_failed_replace_preserves_previous_file(server, tmp_path, monkeypatch):
+    path = tmp_path / "annotations.json"
+    path.write_text("[]")
+
+    def fail(*args):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(os, "replace", fail)
+    with pytest.raises(OSError):
+        server._write_json(path, {"note": "new"})
+    assert path.read_text() == "[]"
+    assert list(tmp_path.iterdir()) == [path]


### PR DESCRIPTION
The review server now honors the chosen state directory instead of always writing to the demo directory. It also fixes failed saves when two changes arrive at the same time.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-evals-course/cartwheel-homeworks/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->