### PR TITLE
Disable implicit OpenAI tracing for non-OpenAI models

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The starter contains unfinished homework functions. Tests for unfinished functio
 uv run python -m agent.cli --role shopper --user 1
 ```
 
-CLI tracing is off by default. Add `--debug` to print tool calls and results locally. To send traces to OpenAI, add `--trace-openai` and set `OPENAI_API_KEY`; OpenAI hosted tracing is unavailable for zero-data-retention organizations. For the course's Langfuse setup, use `--trace` instead. The two tracing flags cannot be combined. `OPENAI_AGENTS_DISABLE_TRACING=1` disables SDK tracing for either destination.
+CLI tracing is off by default. Building a non-OpenAI agent (including Ollama through LiteLLM) also removes the SDK's implicit OpenAI exporter for direct runs. Tracing destinations are process-wide; select Langfuse or explicitly opt into OpenAI tracing before running agents. Add `--debug` to print tool calls and results locally. To send traces to OpenAI, add `--trace-openai` and set `OPENAI_API_KEY`; OpenAI hosted tracing is unavailable for zero-data-retention organizations. For the course's Langfuse setup, use `--trace` instead. The two tracing flags cannot be combined. `OPENAI_AGENTS_DISABLE_TRACING=1` disables SDK tracing for either destination.
 
 The default development seed is the executable course world: 20 stores, 800
 products, 525 users, 10,000 orders, and 18 policy documents. The seed script

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -28,7 +28,7 @@ from agent.auth import AuthContext, can_refund_order, can_view_order, permission
 from agent.config import load_facts
 from agent.helpcenter import get_index
 from agent.killswitch import kill_switch
-from observability.instrument import record_tool_result
+from observability.instrument import configure_model_tracing, record_tool_result
 from seed.eligibility import refund_needs_approval
 
 # ---------------------------------------------------------------------------
@@ -492,6 +492,7 @@ def build_agent(
     it, never a replacement for it.
     """
     resolved = resolve_model(model)
+    configure_model_tracing(openai_model=isinstance(resolved, str))
     if not defenses:
         return Agent[AuthContext](
             name="cartwheel-support",

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -40,7 +40,7 @@ from agent import db
 from agent.agent import build_agent, prompt_version, render_system_prompt
 from agent.auth import AuthContext
 from agent.config import REPO_ROOT
-from observability.instrument import load_env, setup_tracing
+from observability.instrument import load_env, setup_openai_tracing, setup_tracing
 
 DEFAULT_USERS = {"shopper": 1, "merchant": 9001, "support": 9501}
 MAX_TURNS = 12  # cap runaway loops; keeps conversations bounded
@@ -204,7 +204,14 @@ def main() -> None:
     args = parser.parse_args()
 
     load_env()
-    tracing = setup_tracing() if args.trace else args.trace_openai
+    tracing = False
+    if args.trace:
+        tracing = setup_tracing()
+    elif args.trace_openai:
+        try:
+            tracing = setup_openai_tracing()
+        except ValueError as exc:
+            parser.error(str(exc))
     ctx = resolve_auth(args.role, args.user)
     asyncio.run(
         chat(ctx, args.model, defenses=args.defenses, debug=args.debug, tracing=tracing)

--- a/observability/instrument.py
+++ b/observability/instrument.py
@@ -17,6 +17,8 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from agents.tracing import set_trace_processors
+from agents.tracing.processors import default_processor
 from opentelemetry import trace
 
 if TYPE_CHECKING:
@@ -26,6 +28,28 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 log = logging.getLogger("cartwheel.instrument")
 
 _genai_instrumented = False
+_openai_tracing_enabled = False
+
+
+def configure_model_tracing(*, openai_model: bool) -> None:
+    """Remove implicit hosted export for non-OpenAI models.
+
+    SDK processors are process-wide. Preserve either explicitly selected course
+    destination; do not globally disable spans, which would also break Langfuse.
+    """
+    if not openai_model and not _genai_instrumented and not _openai_tracing_enabled:
+        set_trace_processors([])
+
+
+def setup_openai_tracing() -> bool:
+    """Explicitly select hosted tracing, including for non-OpenAI inference."""
+    global _openai_tracing_enabled
+    if not os.environ.get("OPENAI_API_KEY", "").strip():
+        raise ValueError("--trace-openai requires OPENAI_API_KEY; omit the flag for local chat")
+    set_trace_processors([default_processor()])
+    _openai_tracing_enabled = True
+    return True
+
 
 
 def instrument_genai(tracer_provider: Any) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ import asyncio
 import httpx
 import langfuse
 import pytest
-from agents import Agent, function_tool
+from agents import Agent, Runner, function_tool
 from agents.tracing import get_trace_provider, set_trace_provider, trace
 from agents.tracing.processors import BackendSpanExporter, BatchTraceProcessor
 from agents.tracing.provider import DefaultTraceProvider
@@ -28,6 +28,7 @@ def hosted_exports(monkeypatch):
     """Isolate SDK tracing and capture hosted exports without network calls."""
     monkeypatch.setattr(instrument, "load_env", lambda: None)
     monkeypatch.setattr(instrument, "_genai_instrumented", False)
+    monkeypatch.setattr(instrument, "_openai_tracing_enabled", False)
     requests = []
 
     def reject_export(request):
@@ -38,6 +39,7 @@ def hosted_exports(monkeypatch):
     exporter._client.close()
     exporter._client = httpx.Client(transport=httpx.MockTransport(reject_export))
     hosted_processor = BatchTraceProcessor(exporter)
+    monkeypatch.setattr(instrument, "default_processor", lambda: hosted_processor)
     previous_provider = get_trace_provider()
     provider = DefaultTraceProvider()
     provider.set_disabled(False)
@@ -76,6 +78,7 @@ def test_cli_tool_results(debug, tracing, tmp_path, monkeypatch, capsys, caplog,
     messages = iter(["Check both orders", "quit"])
     argv = ["agent.cli"] + (["--debug"] if debug else [])
     if tracing == "openai":
+        monkeypatch.setenv("OPENAI_API_KEY", "offline-placeholder")
         argv.append("--trace-openai")
     elif tracing != "plain":
         argv.append("--trace")
@@ -172,3 +175,85 @@ def test_instrumentation_failure_does_not_report_success(monkeypatch) -> None:
     with pytest.raises(RuntimeError, match="failed to install"):
         instrument.instrument_genai(NoOpTracerProvider())
     assert instrument._genai_instrumented is False
+
+
+@pytest.mark.parametrize("has_key", [False, True])
+@pytest.mark.parametrize("model_name", ["ollama_chat/local-model", "claude-opus-4-6"])
+def test_non_openai_direct_run_does_not_export(
+    has_key, model_name, monkeypatch, hosted_exports, caplog,
+) -> None:
+    from agent import agent as support
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    if has_key:
+        monkeypatch.setenv("OPENAI_API_KEY", "offline-placeholder")
+    else:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    # Exercise real provider selection and agent construction, replacing only
+    # the remote model call with an offline implementation.
+    agent = support.build_agent(AuthContext(user_id=1, role="shopper"), model=model_name)
+    assert isinstance(agent.model, LitellmModel)
+    model = FakeModel()
+    model.set_next_output([text_message("Local response")])
+    agent.model = model
+    result = asyncio.run(Runner.run(agent, "Hello"))
+    assert result.final_output == "Local response"
+    processor, requests = hosted_exports
+    processor.force_flush()
+    assert requests == []
+    assert "skipping trace export" not in caplog.text
+
+
+def test_non_openai_direct_run_preserves_langfuse(monkeypatch, hosted_exports) -> None:
+    from agent import agent as support
+
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    try:
+        # First disable implicit export, then explicitly enable local OTel.
+        support.build_agent(AuthContext(user_id=1, role="shopper"), model="ollama_chat/local")
+        instrument.instrument_genai(provider)
+        agent = support.build_agent(AuthContext(user_id=1, role="shopper"), model="ollama_chat/local")
+        model = FakeModel()
+        model.set_next_output([text_message("Local response")])
+        agent.model = model
+        result = asyncio.run(Runner.run(agent, "Hello"))
+        assert result.final_output == "Local response"
+        assert exporter.get_finished_spans()
+        processor, requests = hosted_exports
+        processor.force_flush()
+        assert requests == []
+    finally:
+        provider.shutdown()
+
+
+def test_non_openai_explicit_hosted_export(monkeypatch, hosted_exports) -> None:
+    from agent import agent as support
+
+    # An explicit choice can restore hosted export after a local-only run.
+    ctx = AuthContext(user_id=1, role="shopper")
+    support.build_agent(ctx, model="ollama_chat/local")
+    monkeypatch.setenv("OPENAI_API_KEY", "offline-placeholder")
+    instrument.setup_openai_tracing()
+    agent = support.build_agent(ctx, model="ollama_chat/local")
+    model = FakeModel()
+    model.set_next_output([text_message("Local response")])
+    agent.model = model
+    assert asyncio.run(Runner.run(agent, "Hello")).final_output == "Local response"
+    processor, requests = hosted_exports
+    processor.force_flush()
+    assert len(requests) == 1
+
+
+def test_explicit_hosted_export_requires_key(monkeypatch, hosted_exports, capsys) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(cli, "load_env", lambda: None)
+    monkeypatch.setattr("sys.argv", ["agent.cli", "--trace-openai"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 2
+    assert "--trace-openai requires OPENAI_API_KEY" in capsys.readouterr().err
+    processor, requests = hosted_exports
+    processor.force_flush()
+    assert requests == []


### PR DESCRIPTION
Non-OpenAI agents can inherit the OpenAI Agents SDK's hosted trace exporter during direct runs, producing `OPENAI_API_KEY is not set, skipping trace export` or exporting unintentionally when a key happens to exist. Agent construction now removes that implicit exporter for non-OpenAI models. The CLI already disabled tracing for plain chats; this protects direct SDK runs as well.

Explicit Langfuse tracing remains intact. `--trace-openai` remains an opt-in for either model provider and now rejects missing credentials before starting the chat. Tracing destinations are process-wide, as in the SDK; the README documents selecting a destination before running agents.

Validation: `uv run pytest -q` — 116 passed, 12 skipped, 27 expected failures from homework placeholders. Regression tests use the real SDK runner with offline model responses and intercepted hosted HTTP exports. They cover non-OpenAI runs with and without an OpenAI key, Langfuse span delivery, explicit hosted export, and missing-key validation. No live inference or remote trace export was used.

The student's checkout version is unknown; their screenshot was not reproduced against current main. This change closes the remaining implicit-export path rather than claiming the current CLI default is broken.

Fixes #16.
