### PR TITLE
QoL improvement for CLI editing

### DIFF
--- a/agent/cli.py
+++ b/agent/cli.py
@@ -32,6 +32,11 @@ import asyncio
 import json
 import time
 
+try:  # readline transparently upgrades input(): arrow keys, ctrl-a/e/k/w,
+    import readline  # noqa: F401  # and up-arrow recall within this session
+except ImportError:  # Windows and slim builds ship without it
+    pass
+
 from agents import RunConfig, Runner, SQLiteSession
 from agents.items import RunItem
 from opentelemetry import trace


### PR DESCRIPTION
Hopefully this PR isn't too annoying. A couple line fix that adds readline support to the input of the CLI when editing on macos or linux. This should allow editing keybinds to work instead of appearing as `^A`, for example.
