### PR TITLE
HW1: make sure cancel_order checks ownership before order status

### DIFF
--- a/tests/test_hw_holes.py
+++ b/tests/test_hw_holes.py
@@ -111,6 +111,8 @@ def test_hw1_cancel_order(world_copy: Path) -> None:
     denied = tools.cancel_order(stranger, order_id, "not mine")
     assert denied["ok"] is False
     assert denied["error"] == "permission_denied"
+    # Even when the order is already delivered: a stranger must get
+    # permission_denied, not not_eligible, or they learn its status.
     assert tools.cancel_order(SHOPPER_2, 4127, "not mine")["error"] == "permission_denied"
 
     # Pre-shipment rule: a delivered order is not cancellable even in scope.

--- a/tests/test_hw_holes.py
+++ b/tests/test_hw_holes.py
@@ -111,6 +111,7 @@ def test_hw1_cancel_order(world_copy: Path) -> None:
     denied = tools.cancel_order(stranger, order_id, "not mine")
     assert denied["ok"] is False
     assert denied["error"] == "permission_denied"
+    assert tools.cancel_order(SHOPPER_2, 4127, "not mine")["error"] == "permission_denied"
 
     # Pre-shipment rule: a delivered order is not cancellable even in scope.
     delivered = tools.cancel_order(SHOPPER_1, 4127, "too late")


### PR DESCRIPTION
## Summary
**Why:** The HW1 `cancel_order` test only checked that a shopper could cancel their own order and that a *delivered* order can't be cancelled. It never checked what happens when someone tries to cancel an order that isn't theirs. That let a student write `cancel_order` so it looks at the order's status *before* checking who is asking — and then a stranger could learn "this order is already delivered" about someone else's order, which is a privacy leak.

**What this does:** Adds one line to the test: shopper 2 tries to cancel shopper 1's order and must get `permission_denied` (not `not_eligible`). Now an implementation that checks status before ownership fails the test.

Closes #31


Link to Devin session: https://app.devin.ai/sessions/3b60ba1350904acdab9d6a0c4749c040
Open in Devin Desktop: https://app.devin.ai/desktop/session/3b60ba1350904acdab9d6a0c4749c040?variant=devin