### PR TITLE
HW1: stop the model from choosing whose identity a new tool runs as

### DIFF
--- a/homework/module-1/hw1.md
+++ b/homework/module-1/hw1.md
@@ -110,7 +110,13 @@ During Part B conversations you will notice things the agent cannot do because n
 - Look up public store information and policy overrides
 - Summarize a customer's recent order history
 
-To add a tool, write the logic as a plain function in `agent/tools.py` that takes `ctx: AuthContext` first, then add a wrapper in `agent/agent.py` that takes `wrapper: RunContextWrapper[AuthContext]`, is decorated with `@function_tool`, has a clear docstring (the SDK uses it as the tool description the model sees), and returns `_call(wrapper, hw_tools.<name>, ...)`, like `get_policy` does. Then add the wrapper to `TOOLS_BY_ROLE` for the appropriate roles. Never decorate a function whose first parameter is `AuthContext` directly: the SDK would expose `ctx` as a model-supplied argument, letting the model claim another user's identity.
+To add a tool, follow the pattern `get_policy` already uses:
+
+1. In `agent/tools.py`, write the tool as a plain function whose first parameter is `ctx: AuthContext` (the logged-in user). No decorator.
+2. In `agent/agent.py`, add a small wrapper decorated with `@function_tool`. Its first parameter is `wrapper: RunContextWrapper[AuthContext]`, its docstring is the tool description the model sees, and its body is `return _call(wrapper, hw_tools.<your_function>, <other args>)`.
+3. Add the wrapper to `TOOLS_BY_ROLE` for the roles that should have it.
+
+Do not put `@function_tool` on the `agent/tools.py` function itself. The SDK turns every parameter of a decorated function into something the model fills in, so `ctx` would become a value the model chooses, and it could claim to be any user. The wrapper is what keeps the real user's identity out of the model's hands.
 
 Then run the supplied tests for the completed tools, authorization rules, and refund rules:
 

--- a/homework/module-1/hw1.md
+++ b/homework/module-1/hw1.md
@@ -110,7 +110,7 @@ During Part B conversations you will notice things the agent cannot do because n
 - Look up public store information and policy overrides
 - Summarize a customer's recent order history
 
-To add a tool, write a function decorated with `@function_tool` in `agent/tools.py` with a clear docstring (the SDK uses it as the tool description the model sees), then add it to `TOOLS_BY_ROLE` in `agent/agent.py` for the appropriate roles.
+To add a tool, write the logic as a plain function in `agent/tools.py` that takes `ctx: AuthContext` first, then add a wrapper in `agent/agent.py` that takes `wrapper: RunContextWrapper[AuthContext]`, is decorated with `@function_tool`, has a clear docstring (the SDK uses it as the tool description the model sees), and returns `_call(wrapper, hw_tools.<name>, ...)`, like `get_policy` does. Then add the wrapper to `TOOLS_BY_ROLE` for the appropriate roles. Never decorate a function whose first parameter is `AuthContext` directly: the SDK would expose `ctx` as a model-supplied argument, letting the model claim another user's identity.
 
 Then run the supplied tests for the completed tools, authorization rules, and refund rules:
 


### PR DESCRIPTION
## Summary
**Why:** The HW1 "add a tool" instructions told students to put `@function_tool` straight onto a function in `agent/tools.py`. Those functions take `ctx: AuthContext` (who is logged in) as their first argument, so the SDK would expose `ctx` as something the *model* fills in — meaning the model could simply say "I'm user 42" and act as anyone.

**What this does:** Rewrites that one paragraph to follow the pattern the existing `get_policy` tool already uses: keep the logic in `agent/tools.py`, and add a tiny `@function_tool` wrapper in `agent/agent.py` that pulls the real logged-in user from `RunContextWrapper[AuthContext]` and passes it along. Adds an explicit warning never to decorate an `AuthContext`-first function directly. Docs only.

Closes #30


Link to Devin session: https://app.devin.ai/sessions/3b60ba1350904acdab9d6a0c4749c040
Open in Devin Desktop: https://app.devin.ai/desktop/session/3b60ba1350904acdab9d6a0c4749c040?variant=devin