### PR TITLE
Prevent duplicate refund requests

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -224,7 +224,7 @@ def issue_refund_logic(
                 "error": "invalid_argument",
                 "reason": f"refund amount ${amount_usd:.2f} exceeds order total ${order.total_usd:.2f}",
             }
-        if not order.refund_eligible:
+        if not order.refund_eligible or order.status != "delivered":
             return {
                 "ok": False,
                 "error": "not_eligible",
@@ -233,6 +233,12 @@ def issue_refund_logic(
                     f"(status '{order.status}', delivered {order.delivered_at}); "
                     f"the return window counts from the delivery date"
                 ),
+            }
+        if db.has_refund_for_order(conn, order_id):
+            return {
+                "ok": False,
+                "error": "not_eligible",
+                "reason": f"order #{order_id} already has a refund request",
             }
         today = db.world_asof(conn).isoformat()
         threshold = facts["refund_auto_approve_threshold_usd"]

--- a/agent/db.py
+++ b/agent/db.py
@@ -228,8 +228,21 @@ def list_products(
 
 
 def set_order_status(conn: sqlite3.Connection, order_id: int, status: str) -> None:
-    conn.execute("UPDATE orders SET status = ? WHERE id = ?", (status, order_id))
+    if status == "delivered":
+        conn.execute("UPDATE orders SET status = ? WHERE id = ?", (status, order_id))
+    else:
+        conn.execute(
+            "UPDATE orders SET status = ?, refund_eligible = 0 WHERE id = ?",
+            (status, order_id),
+        )
     conn.commit()
+
+
+def has_refund_for_order(conn: sqlite3.Connection, order_id: int) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM refunds WHERE order_id = ? LIMIT 1", (order_id,)
+    ).fetchone()
+    return row is not None
 
 
 def insert_refund(

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -54,22 +54,30 @@ def test_refund_below_threshold_auto_approves(world_copy: Path) -> None:
     result = issue_refund_logic(SHOPPER_1, 4127, 84.0, "arrived chipped")
     assert result["ok"] is True
     assert result["status"] == "auto_approved"
+    duplicate = issue_refund_logic(SHOPPER_1, 4127, 84.0, "arrived chipped")
+    assert duplicate["ok"] is False
+    assert duplicate["error"] == "not_eligible"
     conn = sqlite3.connect(world_copy)
     try:
-        status = conn.execute("SELECT status FROM orders WHERE id = 4127").fetchone()[0]
-        refund = conn.execute(
-            "SELECT status, amount_cents FROM refunds WHERE order_id = 4127"
+        order = conn.execute(
+            "SELECT status, refund_eligible FROM orders WHERE id = 4127"
         ).fetchone()
+        refunds = conn.execute(
+            "SELECT status, amount_cents FROM refunds WHERE order_id = 4127"
+        ).fetchall()
     finally:
         conn.close()
-    assert status == "refunded"
-    assert refund == ("auto_approved", 8400)
+    assert order == ("refunded", 0)
+    assert refunds == [("auto_approved", 8400)]
 
 
 def test_refund_above_threshold_queues(world_copy: Path) -> None:
     result = issue_refund_logic(SHOPPER_1, 4455, 240.0, "wrong item")
     assert result["ok"] is True
     assert result["status"] == "queued_for_approval"
+    duplicate = issue_refund_logic(SHOPPER_1, 4455, 240.0, "wrong item")
+    assert duplicate["ok"] is False
+    assert duplicate["error"] == "not_eligible"
     conn = sqlite3.connect(world_copy)
     try:
         # Queued means no money moved: the order is untouched.


### PR DESCRIPTION
Fixes #28.

`issue_refund` could create more than one refund record for an order because it trusted a stored eligibility flag after the order status changed. A repeated full refund was approved, and an order with a queued refund could accept another queued or automatic refund.

The tool now rejects an order when its current status is not `delivered` or it already has a refund request. Status updates also clear the stored eligibility flag when the order leaves `delivered`. The tests repeat automatic and queued refund requests and confirm that the database stores only one refund record.

## Validation

`.venv/bin/pytest -q`

133 passed, 12 skipped, and 30 expected failures from unfinished homework functions.
