### PR TITLE
Require HW3 scenarios for known failure cases

### DIFF
--- a/homework/module-1/hw3.md
+++ b/homework/module-1/hw3.md
@@ -98,6 +98,11 @@ You will run a small pilot before creating all 250 scenarios. The pilot gives yo
 
 Have the coding agent generate `scenarios/pilot_scenarios.jsonl` with the skill: 30 scenarios with broad role and intent coverage, including ordinary requests and difficult requests from the dimensions in Part A.
 
+Include both required diagnostic cases in the pilot:
+
+- Shopper user `392` asks for the return deadline on order `8002`. The order is marked delivered but has no delivery date, so the expected result must say not to compute a deadline.
+- Shopper user `1` requests the full $84 refund for order `4127`, then asks for the same refund again in a followup. Set `tuple.intent` to `repeat_refund`. The expected result must say that the second request is `not_eligible` because the first refund changed the order status to `refunded`, and it must cite `seed/eligibility.py`. Do not use order `4127` in another write scenario in the same run.
+
 Each scenario must record what the agent should do and the source that supports the answer. For example, if an order has no delivery date, the scenario records that the agent must not calculate a return deadline and cites the damaged record. The scenario skill shows the required JSON fields.
 
 Validate the file, then run the scenarios on your selected model. Replace `YOUR_MODEL` with the value of `CARTWHEEL_MODEL` in `.env`:
@@ -110,6 +115,8 @@ uv run python -m scenarios.runner scenarios/pilot_scenarios.jsonl \
 ```
 
 Review at least 10 pilot results in Langfuse. Start with difficult scenarios and cases where the model used an unexpected tool, changed data, or gave an answer that conflicts with the recorded expected result.
+
+Review both required diagnostic cases. Record whether the observed agent behavior failed the expected result. Keep a valid case even when the agent handles it correctly, because Homework 4 needs both successes and failures.
 
 Create `scenarios/pilot_review.jsonl` with one record for each scenario you review. Record:
 
@@ -133,6 +140,7 @@ Save the final dataset in `scenarios/support_scenarios.jsonl`. It must contain:
 
 - 175 scenarios with `scenario_group` set to `coverage`.
 - 75 scenarios with `scenario_group` set to `challenge`, including five for each of the six damaged records.
+- A new version of the `repeat_refund` challenge used in the pilot. Keep it as the only scenario that writes to order `4127` in the final run.
 
 Give every final scenario a new identifier, distinct from the pilot identifiers. The export in Part E selects traces by scenario identifier, so a reused identifier would pull in the pilot run's traces as well.
 
@@ -152,7 +160,7 @@ Validate the final file:
 uv run python -m scenarios.validate scenarios/support_scenarios.jsonl --final
 ```
 
-The command checks the schema, unique identifiers, group counts, turn counts, duplicate conversations, and damaged record coverage. Repair every reported error before starting the final run, because the run makes model calls for every scenario.
+The command checks the schema, unique identifiers, group counts, turn counts, duplicate conversations, damaged record coverage, access to damaged orders, and the required repeat-refund challenge. Repair every reported error before starting the final run, because the run makes model calls for every scenario.
 
 ## Part D, run the final dataset
 

--- a/scenarios/skill/SKILL.md
+++ b/scenarios/skill/SKILL.md
@@ -49,6 +49,15 @@ application's database, policies, or expected outcomes.
    put one or two exact user utterances in `followups`; the runner sends every
    string verbatim, so do not place persona notes or generation instructions
    in the field.
+   Include both required diagnostic cases in the pilot and final sets:
+   - Shopper 392 asks for the return deadline on order 8002, whose delivery
+     date is missing. The expected result must say not to compute a deadline.
+   - Shopper 1 requests a full refund for order 4127 and then asks for the same
+     refund again in a followup. The expected result must say that the second
+     request is `not_eligible` because the first refund changed the order's
+     status to `refunded`. Use `repeat_refund` as the intent and the eligibility
+     function as the expected source. Do not use order 4127 in another write
+     scenario in the same run.
 4. Check for duplicate requests, unrealistic phrasing, and missing dimension
    values. Assign `scenario_group` as `coverage` or `challenge`. The coverage
    group exercises the planned dimensions. The challenge group concentrates
@@ -78,7 +87,7 @@ application's database, policies, or expected outcomes.
   "id": "support-0042",
   "scenario_group": "challenge",
   "data_quality_case_id": "dq-order-missing-delivery-date",
-  "tuple": {"role": "shopper", "intent": "return_deadline", "record_state": "order_missing_delivery_date", "applicable_policy": "cw-returns", "tools_needed": "one_lookup", "turn_count": 1, "difficulty": "boundary", "order_id": 8002},
+  "tuple": {"role": "shopper", "user_id": 392, "intent": "return_deadline", "record_state": "order_missing_delivery_date", "applicable_policy": "cw-returns", "tools_needed": "one_lookup", "turn_count": 1, "difficulty": "boundary", "order_id": 8002},
   "opening_message": "When does the return period end for order 8002?",
   "followups": [],
   "expected": {
@@ -125,7 +134,9 @@ needs to find.
 an ordinary scenario. A scenario involving a documented defect uses the
 matching identifier from `data_quality_cases`, belongs to the challenge
 group, uses an objective `data_quality_table` source, and records the affected
-`product_id` or `order_id` in `tuple`.
+`product_id` or `order_id` in `tuple`. For an order, record `tuple.user_id`
+explicitly and choose a user who can view it. The runner uses `tuple.user_id`
+when it creates the session and otherwise uses the default user for the role.
 
 ## Known limits
 

--- a/scenarios/validate.py
+++ b/scenarios/validate.py
@@ -15,10 +15,12 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
+from agent.auth import AuthContext, can_view_order
 from agent.config import db_path
 
 GROUPS = {"coverage", "challenge"}
 ROLES = {"shopper", "merchant", "support"}
+REPEAT_REFUND_INTENT = "repeat_refund"
 REQUIRED_TUPLE_FIELDS = {
     "role",
     "intent",
@@ -86,8 +88,9 @@ def validate_scenarios(
     """Validate records and return a compact summary.
 
     In final mode, the database manifest is also used to prove that every
-    documented defect has five challenge scenarios and that each scenario's
-    tuple points at the affected entity.
+    documented defect has five challenge scenarios, each damaged-order
+    scenario uses an identity that can view the order, and the repeat-refund
+    diagnostic is present.
     """
     errors: list[str] = []
     ids: list[str] = []
@@ -95,6 +98,9 @@ def validate_scenarios(
     groups: Counter[str] = Counter()
     dq_counts: Counter[str] = Counter()
     dq_rows: dict[str, tuple[str, int]] = {}
+    order_scopes: dict[int, tuple[int, int]] = {}
+    users: dict[int, tuple[str, int | None]] = {}
+    repeat_refund_count = 0
 
     if final:
         database = db or db_path()
@@ -107,6 +113,18 @@ def validate_scenarios(
             rows = conn.execute(
                 "SELECT case_id, entity_type, entity_id FROM data_quality_cases"
             ).fetchall()
+            order_scopes = {
+                order_id: (user_id, store_id)
+                for order_id, user_id, store_id in conn.execute(
+                    "SELECT id, user_id, store_id FROM orders"
+                )
+            }
+            users = {
+                user_id: (role, store_id)
+                for user_id, role, store_id in conn.execute(
+                    "SELECT id, role, store_id FROM users"
+                )
+            }
         finally:
             conn.close()
         dq_rows = {case_id: (entity_type, entity_id) for case_id, entity_type, entity_id in rows}
@@ -171,6 +189,27 @@ def validate_scenarios(
                 conversations.append(tuple(message.strip().casefold() for message in messages))
         _validate_expected(scenario.get("expected"), label, errors)
 
+        if tuple_.get("intent") == REPEAT_REFUND_INTENT:
+            repeat_refund_count += 1
+            acting_user = tuple_.get("user_id")
+            if (
+                group != "challenge"
+                or tuple_.get("role") != "shopper"
+                or acting_user != 1
+                or tuple_.get("order_id") != 4127
+                or not isinstance(followups, list)
+                or len(followups) < 1
+            ):
+                errors.append(
+                    f"{label}: repeat_refund must be a multi-turn challenge for shopper 1 and order 4127"
+                )
+            expected = scenario.get("expected", {})
+            source = expected.get("source", {}) if isinstance(expected, dict) else {}
+            if source.get("type") != "eligibility_function":
+                errors.append(
+                    f"{label}: repeat_refund expected source must use the eligibility_function"
+                )
+
         dq_id = scenario.get("data_quality_case_id")
         if dq_id is not None:
             if not _nonempty_string(dq_id):
@@ -187,6 +226,10 @@ def validate_scenarios(
                     errors.append(
                         f"{label}: data-quality expected source must reference {dq_id!r}"
                     )
+                if dq_id.startswith("dq-order-") and "user_id" not in tuple_:
+                    errors.append(
+                        f"{label}: a data-quality order scenario must include tuple.user_id"
+                    )
                 if final:
                     manifest = dq_rows.get(dq_id)
                     if manifest is None:
@@ -198,6 +241,29 @@ def validate_scenarios(
                             errors.append(
                                 f"{label}: tuple.{entity_key} must be {entity_id} for {dq_id}"
                             )
+                        if entity_type == "order" and entity_id in order_scopes:
+                            role = tuple_.get("role")
+                            acting_user = tuple_.get("user_id")
+                            user = users.get(acting_user)
+                            if user is None:
+                                errors.append(
+                                    f"{label}: tuple.user_id {acting_user!r} does not exist"
+                                )
+                            elif user[0] != role:
+                                errors.append(
+                                    f"{label}: user {acting_user} has role {user[0]!r}, not {role!r}"
+                                )
+                            else:
+                                order_user_id, order_store_id = order_scopes[entity_id]
+                                ctx = AuthContext(
+                                    user_id=acting_user,
+                                    role=role,
+                                    store_id=user[1] if role == "merchant" else None,
+                                )
+                                if not can_view_order(ctx, order_user_id, order_store_id):
+                                    errors.append(
+                                        f"{label}: {role} user {acting_user} cannot view order {entity_id}"
+                                    )
 
     duplicates = sorted(key for key, count in Counter(ids).items() if count > 1)
     if duplicates:
@@ -224,6 +290,10 @@ def validate_scenarios(
                 errors.append(
                     f"final dataset must contain 5 scenarios for {case_id}, found {dq_counts[case_id]}"
                 )
+        if repeat_refund_count < 1:
+            errors.append(
+                "final dataset must contain a repeat_refund challenge for shopper 1 and order 4127"
+            )
 
     if errors:
         raise ScenarioValidationError("scenario validation failed:\n- " + "\n- ".join(errors))

--- a/tests/test_scenario_validation.py
+++ b/tests/test_scenario_validation.py
@@ -68,6 +68,25 @@ def test_pilot_validation_rejects_duplicate_conversations() -> None:
         validate_scenarios([first, second])
 
 
+def test_pilot_validation_requires_user_for_data_quality_order() -> None:
+    scenario = valid_scenario()
+    scenario.update(
+        scenario_group="challenge",
+        data_quality_case_id="dq-order-missing-delivery-date",
+    )
+    scenario["tuple"]["order_id"] = 8002
+    scenario["expected"] = {
+        "evaluation": "objective",
+        "outcome": "do_not_compute_return_deadline",
+        "source": {
+            "type": "data_quality_table",
+            "reference": "dq-order-missing-delivery-date",
+        },
+    }
+    with pytest.raises(ScenarioValidationError, match="must include tuple.user_id"):
+        validate_scenarios([scenario])
+
+
 def test_final_validation_enforces_counts_and_dirty_case_entity(world: dict) -> None:
     scenario = valid_scenario()
     scenario.update(
@@ -89,6 +108,27 @@ def test_final_validation_enforces_counts_and_dirty_case_entity(world: dict) -> 
     assert "tuple.order_id must be 8002" in text
     assert "must contain 250 records" in text
     assert "must contain 5 scenarios for dq-order-missing-delivery-date" in text
+    assert "must contain a repeat_refund challenge" in text
+
+
+def test_final_validation_rejects_inaccessible_damaged_order(world: dict) -> None:
+    scenario = valid_scenario()
+    scenario.update(
+        scenario_group="challenge",
+        data_quality_case_id="dq-order-missing-delivery-date",
+    )
+    scenario["tuple"].update(order_id=8002, user_id=1)
+    scenario["expected"] = {
+        "evaluation": "objective",
+        "outcome": "do_not_compute_return_deadline",
+        "source": {
+            "type": "data_quality_table",
+            "reference": "dq-order-missing-delivery-date",
+        },
+    }
+    with pytest.raises(ScenarioValidationError) as exc:
+        validate_scenarios([scenario], final=True, db=world["db"])
+    assert "shopper user 1 cannot view order 8002" in str(exc.value)
 
 
 def test_final_validation_accepts_complete_composition(world: dict) -> None:
@@ -113,11 +153,35 @@ def test_final_validation_accepts_complete_composition(world: dict) -> None:
             scenario = records[175 + offset * 5 + repetition]
             scenario["data_quality_case_id"] = case_id
             scenario["tuple"][entity_key] = entity_id
+            if entity_key == "order_id":
+                if case_id == "dq-order-missing-delivery-date":
+                    scenario["tuple"].update(role="shopper", user_id=392)
+                else:
+                    scenario["tuple"].update(role="support", user_id=9501)
             scenario["expected"] = {
                 "evaluation": "objective",
                 "outcome": "follow_manifest_expected_handling",
                 "source": {"type": "data_quality_table", "reference": case_id},
             }
+
+    repeat_refund = records[205]
+    repeat_refund["tuple"].update(
+        role="shopper",
+        user_id=1,
+        intent="repeat_refund",
+        order_id=4127,
+        turn_count=2,
+    )
+    repeat_refund["opening_message"] = "Refund the full $84 for order 4127."
+    repeat_refund["followups"] = ["Please issue the same full refund again."]
+    repeat_refund["expected"] = {
+        "evaluation": "objective",
+        "outcome": "reject_second_refund_as_not_eligible",
+        "source": {
+            "type": "eligibility_function",
+            "reference": "is_refund_eligible(status='refunded')",
+        },
+    }
 
     summary = validate_scenarios(records, final=True, db=world["db"])
     assert summary == {


### PR DESCRIPTION
Fixes #29.

The missing-delivery-date example ran as shopper 1, who cannot view order 8002. The resulting trace tested a correct permission denial instead of the damaged order behavior, and the final validator accepted the invalid scenario.

HW3 now requires two diagnostic cases in the pilot and final datasets. Shopper 392 tests the missing delivery date on order 8002. Shopper 1 requests a refund for order 4127 and then repeats the request, which exposes the duplicate-refund behavior reported in #28 for later error analysis.

The final validator checks that damaged-order scenarios use an identity with access to the order and that the repeat-refund challenge is present. The duplicate-refund implementation remains unchanged so the scenario can exercise it.

## Validation

`.venv/bin/pytest -q tests/test_scenario_validation.py tests/test_scenario_runner.py tests/test_seed_determinism.py tests/test_auth.py`

25 passed.

The three offline CI test groups also passed with 73 passing tests, 2 skipped tests, and 19 expected failures from unfinished homework functions. No live model was used.
