### PR TITLE
fix: use string type for cartwheel.store_id

### DIFF
--- a/homework/module-1/hw2.md
+++ b/homework/module-1/hw2.md
@@ -51,7 +51,7 @@ Use the active tool span returned by `trace.get_current_span()`. Add the followi
 
 - `cartwheel.user_role`, as a string (same for every tool call in the request)
 - `cartwheel.user_id`, as the decimal user identifier stored in a string (same for every tool call in the request)
-- `cartwheel.store_id`, as an integer when the caller is a merchant (same for every tool call in the request)
+- `cartwheel.store_id`, as a string when the caller is a merchant (same for every tool call in the request)
 - `cartwheel.permission_denied`, as a Boolean value
 - `cartwheel.permission_denied.reason`, when permission was denied
 

--- a/observability/instrument.py
+++ b/observability/instrument.py
@@ -115,7 +115,7 @@ def record_tool_result(ctx: "AuthContext", result: dict[str, Any]) -> None:
 
     OpenLLMetry creates the tool span and records its name, arguments, and
     result. The tool wrappers call this helper before that span ends.
-    Add the caller's user_role and string user_id, plus the integer store_id
+    Add the caller's user_role and string user_id, plus the string store_id
     for merchants, then record the permission decision with the helper below.
     When tracing is off, the active span is non-recording and this is a no-op.
     """


### PR DESCRIPTION
## Summary
- Change `cartwheel.store_id` span attribute from `int` to `str` in `observability/instrument.py`
- Update hw2.md to say "as a string" instead of "as an integer"

Avoids protobuf int64-to-string confusion when traces pass through Langfuse → ClickHouse → JSON export. All other span attributes (`user_id`, `session_id`, `scenario_id`) are already strings.

Raised by a student: the type mismatch between `cartwheel.user_id` (string) and `cartwheel.store_id` (int) causes downstream confusion when downstream consumers read the JSON export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnS66QmSySZ1cYkFgL31Rv